### PR TITLE
Fix @types/react-table version to make typescript happy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,5 @@ styleguide/build/bundle.efd07483.js
 styleguide/build/bundle.efd07483.js.LICENSE
 styleguide/index.html
 .DS_Store
+
+lib/

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/jest": "^24.0.25",
     "@types/numeral": "^0.0.26",
     "@types/react-color": "^3.0.0",
-    "@types/react-table": "^7.0.0",
+    "@types/react-table": "^6.0.0",
     "acorn": "^7.1.0",
     "acorn-jsx": "^5.1.0",
     "babel-loader": "^8.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1220,17 +1220,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-table@^6.8.5":
+"@types/react-table@^6.0.0", "@types/react-table@^6.8.5":
   version "6.8.6"
   resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-6.8.6.tgz#6033868003541777e253478798c4dd0b588f0f3e"
   integrity sha512-mCgyjD1KiMfZMHixOEzv7qXh5TSfmvgNbOb8qKLcTJbnGgsVSalcEdrNqASyaMp79MvdbMzxAcFQ3lftzmH7MA==
-  dependencies:
-    "@types/react" "*"
-
-"@types/react-table@^7.0.0":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.0.3.tgz#ded8918c61c7853c281076988d8ea18612c65967"
-  integrity sha512-iR+zL53bQi10tOpLyFh0L0X1LAf5KhHmeMxjZlIsID2K4L2t00wiZ1kA5j4MvuqfK37LdgWccH72ZmXhitQgdw==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
Fixes the "no default export" issue when trying to build the package.