### PR TITLE
[WIP] Data Explorer table styling changes

### DIFF
--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -17,10 +17,11 @@ export default styled.div<ThemeProps>`
   .ReactTable .rt-thead.-header .rt-th {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
     background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#f2f2f2")};
+    padding: 2.5rem 0.75rem 0.5rem;
   }
   .ReactTable.-striped .rt-tr.-odd > div {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#fff")};
+    background-color: ${props => (props.theme === "dark" ? "#111" : "#fff")};
   }
 
   .ReactTable.-striped .rt-tr.-even > div {

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -10,10 +10,13 @@ interface ThemeProps {
 export default styled.div<ThemeProps>`
   /* React table style customization */
   width: 100%;
+  font-family: System-UI, -apple-system, BlinkMacSystemFont, "Source Sans Pro", sans-serif;
+  font-size: 0.875rem;
+
 
   .ReactTable .rt-thead.-header .rt-th {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#fff")};
+    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#f2f2f2")};
   }
   .ReactTable.-striped .rt-tr.-odd > div {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
@@ -22,7 +25,7 @@ export default styled.div<ThemeProps>`
 
   .ReactTable.-striped .rt-tr.-even > div {
     color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#111" : "#f7f7f7")};
+    background-color: ${props => (props.theme === "dark" ? "#111" : "#fff")};
   }
 
   .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {

--- a/src/css/react-table-hoc-fixed-columns.ts
+++ b/src/css/react-table-hoc-fixed-columns.ts
@@ -36,7 +36,7 @@ export default `
   .rthfc .-filters .rt-th.rthfc-th-fixed-left-last,
   .rthfc .rt-th.rthfc-th-fixed-left-last,
   .rthfc .rt-td.rthfc-td-fixed-left-last {
-    border-right: solid 1px;
+    border-right: solid #BDBDBD 1px;
   }
 
   .rthfc .rt-th.rthfc-th-fixed-right-first,

--- a/src/css/react-table-hoc-fixed-columns.ts
+++ b/src/css/react-table-hoc-fixed-columns.ts
@@ -10,6 +10,7 @@ export default `
   .rthfc .rt-thead.-headerGroups,
   .rthfc .rt-thead.-header {
     z-index: 3;
+    
   }
 
   .rthfc .rt-thead.-filters {
@@ -37,6 +38,7 @@ export default `
   .rthfc .rt-th.rthfc-th-fixed-left-last,
   .rthfc .rt-td.rthfc-td-fixed-left-last {
     border-right: solid #BDBDBD 1px;
+    background: #fff;
   }
 
   .rthfc .rt-th.rthfc-th-fixed-right-first,

--- a/src/css/react-table.ts
+++ b/src/css/react-table.ts
@@ -14,7 +14,9 @@ export default `
     -webkit-box-direction: normal;
     -ms-flex-direction: column;
     flex-direction: column;
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    border: 1px solid #BDBDBD;
+    border-radius: 8px;
+    overflow: hidden;
   }
   .ReactTable * {
     box-sizing: border-box;
@@ -73,15 +75,13 @@ export default `
   .ReactTable .rt-thead.-filters .rt-th {
     border-right: 1px solid rgba(0, 0, 0, 0.02);
   }
-  .ReactTable .rt-thead.-header {
-    box-shadow: 0 2px 15px 0 rgba(0, 0, 0, 0.15);
-  }
+
   .ReactTable .rt-thead .rt-tr {
     text-align: center;
   }
   .ReactTable .rt-thead .rt-th,
   .ReactTable .rt-thead .rt-td {
-    padding: 5px 5px;
+    padding: 2.5rem 0.75rem 0.5rem;
     line-height: normal;
     position: relative;
     border-right: 1px solid rgba(0, 0, 0, 0.05);
@@ -113,6 +113,7 @@ export default `
   .ReactTable .rt-thead .rt-resizable-header-content {
     overflow: hidden;
     text-overflow: ellipsis;
+    text-align: left;
   }
   .ReactTable .rt-thead .rt-header-pivot {
     border-right-color: #f7f7f7;
@@ -152,9 +153,6 @@ export default `
     -ms-flex-direction: column;
     flex-direction: column;
     overflow: auto;
-  }
-  .ReactTable .rt-tbody .rt-tr-group {
-    border-bottom: solid 1px rgba(0, 0, 0, 0.05);
   }
   .ReactTable .rt-tbody .rt-tr-group:last-child {
     border-bottom: 0;
@@ -199,7 +197,7 @@ export default `
     flex: 1 0 0;
     white-space: nowrap;
     text-overflow: ellipsis;
-    padding: 7px 5px;
+    padding: 0.5625rem 0.75rem;
     overflow: hidden;
     transition: 0.3s ease;
     transition-property: width, min-width, padding, opacity;
@@ -284,7 +282,6 @@ export default `
     -ms-flex-wrap: wrap;
     flex-wrap: wrap;
     padding: 3px;
-    box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.1);
     border-top: 2px solid rgba(0, 0, 0, 0.1);
   }
   .ReactTable .-pagination input,

--- a/src/css/react-table.ts
+++ b/src/css/react-table.ts
@@ -78,10 +78,10 @@ export default `
 
   .ReactTable .rt-thead .rt-tr {
     text-align: center;
+    background: #ffffff;
   }
   .ReactTable .rt-thead .rt-th,
   .ReactTable .rt-thead .rt-td {
-    padding: 2.5rem 0.75rem 0.5rem;
     line-height: normal;
     position: relative;
     border-right: 1px solid rgba(0, 0, 0, 0.05);


### PR DESCRIPTION
I created a thread to have back and forth conversations regarding some table visual changes to data explorer. 

![Screen Shot 2020-02-15 at 4 30 46 PM](https://user-images.githubusercontent.com/13098025/74597238-be434580-5010-11ea-97e5-aa0a648350d0.png)

From someone unfamiliar with data, I thought design work here would be the easiest to assess and make changes quickly. Inspiration for this was primarily taken from Google Spreadsheets and Airtable. @emeeks suggested some changes according to [best practices among table design](https://www.darkhorseanalytics.com/blog/clear-off-the-tableurl). I have not yet finished implementing all of the style changes as suggested.

Some other things to note in general that I wanted to work on
1. Filtering interaction
1. Styling of buttons to change to various graphs/charts to include labels.
1. Limiting the use of color for visualizations. 

I also had a question about pagination and existing 20-row defaults. What was the thought process behind us doing that? I was considering suggesting changes, but it is difficult to do so without getting the right context.  

I figured this to be a good starting point for feedback.  Let me know what thoughts we have on what I've worked on so far, but whether there is some low hanging fruit that I can tackle and that this project can benefit a lot from. 


