### PR TITLE
Optimize facets

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-color": "^2.14.1",
     "react-table": "6.11.5",
     "react-table-hoc-fixed-columns": "2.1.3",
-    "semiotic": "^2.0.0-beta.12",
+    "semiotic": "^2.0.0-beta.15",
     "ts-jest": "^24.3.0"
   },
   "devDependencies": {

--- a/src/Documentation.md
+++ b/src/Documentation.md
@@ -202,3 +202,74 @@ import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
   <Viz />
 </DataExplorer>;
 ```
+
+### Custom Styling
+
+You can turn on faceting by sending multiple DataExplorer prop objects to the DataExplorer's `facets` property. When you do so, the properties of each object sent to faceting will be extended onto the properties sent to the data explorer, resulting in multiple views (one for each object sent to `facets`).
+
+```jsx
+import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
+
+<DataExplorer
+  data={{...largeVizData}}
+  overrideSettings={{ size: [150,150], axes: [], oLabel: false, margin: 5 }}
+  metadata={{ dx: {
+    facets: [
+    {
+      initialView: "summary",
+      metadata: {
+        dx: {
+          metric1: "Generosity"
+        }
+      }
+    },
+    {
+      initialView: "summary",
+//      dimFacet: { dim: "Region", value: "Western Europe" },
+      metadata: {
+        dx: {
+          metric1: "Dystopia Residual"
+        }
+      }
+    },
+    {
+      initialView: "summary",
+      metadata: {
+        dx: {
+          metric1: "Happiness Score"
+        }
+      }
+    },
+    {
+      initialView: "summary",
+      metadata: {
+        dx: {
+          metric1: "Economy (GDP per Capita)"
+        }
+      }
+    },
+    {
+      initialView: "summary",
+      metadata: {
+        dx: {
+          metric1: "Trust (Government Corruption)"
+        }
+      }
+    },
+    {
+      initialView: "summary",
+      metadata: {
+        dx: {
+          metric1: "Health (Life Expectancy)"
+        }
+      }
+    }
+  ]
+  }
+  } 
+  }
+  initialView="summary"
+>
+  <Viz />
+</DataExplorer>;
+```

--- a/src/charts/settings.tsx
+++ b/src/charts/settings.tsx
@@ -1,7 +1,10 @@
 import {
   ResponsiveNetworkFrame,
   ResponsiveOrdinalFrame,
-  ResponsiveXYFrame
+  ResponsiveXYFrame,
+  NetworkFrame,
+  OrdinalFrame,
+  XYFrame
 } from "semiotic";
 
 import ParallelCoordinatesController from "../components/ParallelCoordinatesController";
@@ -20,53 +23,62 @@ const semioticParallelCoordinates = (
   schema: Dx.Schema,
   options: Dx.ChartOptions
 ) => {
-  return { frameSettings:  {
-    data,
-    schema,
-    options
-  }
-};
+  return {
+    frameSettings: {
+      data,
+      schema,
+      options
+    }
+  };
 };
 
 export const semioticSettings: any = {
   line: {
     Frame: ResponsiveXYFrame,
     controls: "switch between linetype",
-    chartGenerator: semioticLineChart
+    chartGenerator: semioticLineChart,
+    FacetFrame: XYFrame
   },
   scatter: {
     Frame: ResponsiveXYFrame,
     controls: "switch between modes",
-    chartGenerator: semioticScatterplot
+    chartGenerator: semioticScatterplot,
+    FacetFrame: XYFrame
   },
   hexbin: {
     Frame: ResponsiveXYFrame,
     controls: "switch between modes",
-    chartGenerator: semioticHexbin
+    chartGenerator: semioticHexbin,
+    FacetFrame: XYFrame
   },
   bar: {
     Frame: ResponsiveOrdinalFrame,
     controls: "switch between modes",
-    chartGenerator: semioticBarChart
+    chartGenerator: semioticBarChart,
+    FacetFrame: OrdinalFrame
   },
   summary: {
     Frame: ResponsiveOrdinalFrame,
     controls: "switch between modes",
-    chartGenerator: semioticSummaryChart
+    chartGenerator: semioticSummaryChart,
+    FacetFrame: OrdinalFrame
   },
   network: {
     Frame: ResponsiveNetworkFrame,
     controls: "switch between modes",
-    chartGenerator: semioticNetwork
+    chartGenerator: semioticNetwork,
+    FacetFrame: NetworkFrame
   },
   hierarchy: {
     Frame: ResponsiveNetworkFrame,
     controls: "switch between modes",
-    chartGenerator: semioticHierarchicalChart
+    chartGenerator: semioticHierarchicalChart,
+    FacetFrame: NetworkFrame
   },
   parallel: {
     Frame: ParallelCoordinatesController,
     controls: "switch between modes",
-    chartGenerator: semioticParallelCoordinates
+    chartGenerator: semioticParallelCoordinates,
+    FacetFrame: ParallelCoordinatesController
   }
 };

--- a/src/charts/summary.tsx
+++ b/src/charts/summary.tsx
@@ -66,7 +66,7 @@ export const semioticSummaryChart = (
 
   const summarySettings = {
     summaryType: { type: summaryType, bins: 16, amplitude: 20 },
-    type: summaryType === "violin" && "swarm",
+    type: summaryType === "violin" && data.length < 250 && "swarm",
     projection: "horizontal",
     data,
     oAccessor,

--- a/src/components/DataExplorer.tsx
+++ b/src/components/DataExplorer.tsx
@@ -418,7 +418,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
         } else {
             const { Frame, chartGenerator } = semioticSettings[view];
 
-            const baseFrameSettings = chartGenerator(stateData, data!.schema, {
+            const chartSettings = {
                 metrics,
                 dimensions,
                 chart,
@@ -438,15 +438,19 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                 barGrouping,
                 setColor: this.setColor,
                 showLegend
-            });
+            }
+
+            const baseFrameSettings = chartGenerator(stateData, data!.schema, chartSettings);
 
             const { frameSettings } = baseFrameSettings
+
+            const frameOverride = typeof overrideSettings === "function" ? overrideSettings(chartSettings) : overrideSettings
 
             instantiatedView = <Frame
                 responsiveWidth
                 size={defaultResponsiveSize}
                 {...frameSettings}
-                {...overrideSettings}
+                {...frameOverride}
 
             />
         }
@@ -469,7 +473,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                     } else {
                         const { dx: facetDX = {} } = facetMetadata
 
-                        const { Frame: FacetFrame, chartGenerator: facetChartGenerator } = semioticSettings[initialView];
+                        const { FacetFrame, chartGenerator: facetChartGenerator } = semioticSettings[initialView];
 
                         const { data: facetData, schema: facetSchema } = facetDataSettings
 
@@ -477,7 +481,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
 
                         const title = dimFacet ? `${dimFacet.dim}=${dimFacet.value}` : ""
 
-                        const facetFrameSettings = facetChartGenerator(filteredFacetData, facetSchema, {
+                        const facetChartSettings = {
                             metrics,
                             dimensions,
                             chart: { ...chart, ...facetDX },
@@ -498,12 +502,17 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                             setColor: this.setColor,
                             showLegend,
                             ...facetDX
-                        }, colorHashOverride, colorDimOverride)
+                        }
+
+                        const facetFrameSettings = facetChartGenerator(filteredFacetData, facetSchema, facetChartSettings, colorHashOverride, colorDimOverride)
 
                         const { colorHash, frameSettings, colorDim } = facetFrameSettings
 
                         colorHashOverride = colorHashOverride || colorHash
                         colorDimOverride = colorDimOverride || colorDim
+
+                        const facetOverride = typeof overrideSettings === "function" ? overrideSettings(facetDX) : overrideSettings
+
 
                         facetFrames.push(<FacetFrame
                             {...frameSettings}
@@ -519,7 +528,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                             afterElements={null}
                             margin={{ ...frameSettings.margin, ...{ left: 55, right: 25, top: 25 } }}
                             title={title}
-                            {...overrideSettings}
+                            {...facetOverride}
                         />)
                     }
                 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -8118,10 +8118,10 @@ semiotic-mark@0.4.3:
     d3-selection "^1.4.0"
     d3-transition "^1.2.0"
 
-semiotic@^2.0.0-beta.11:
-  version "2.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-beta.11.tgz#5a4f60c14dadc11ee3fda3fc6a2d75d3cada47ae"
-  integrity sha512-08i1HfhVY8YWyduAkJbK4eHeqyauinDo/g/KMe0zPdE3W5FlbG9EtofNQ44bTCTkV9ts9Vn5KG5RWdna97XA0w==
+semiotic@^2.0.0-beta.15:
+  version "2.0.0-beta.15"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-beta.15.tgz#505310496263845638db894fc45898d91816a3d5"
+  integrity sha512-zbY1xVMxebyx25O/eVmaU5Eqn9aMNJ7hroW53qvly9iWQ/gF9Llgl/w7t9bt0mOg3YNdQ9Dp7LFJJj/sD6JM+w==
   dependencies:
     d3-array "^1.2.0"
     d3-brush "^1.0.6"


### PR DESCRIPTION
Facets at first only worked in a style that was basically "2 columns" but now use the non-responsive Semiotic frames under the hood to allow folks to make long rows.

There were also some changes to make the interactivity and performance better when a bunch of some kinds of charts (especially Violin, which is the default in summary) are shown at once.