### PR TITLE
Modular controls

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "numeral": "^2.0.6",
-    "react": "^16.3.2",
+    "react": "^16.13.1",
     "styled-components": ">= 4"
   },
   "files": [
@@ -41,7 +41,7 @@
     "react-color": "^2.14.1",
     "react-table": "6.11.5",
     "react-table-hoc-fixed-columns": "2.1.3",
-    "semiotic": "^2.0.0-rc.0"
+    "semiotic": "^2.0.0-rc.1"
   },
   "devDependencies": {
     "@babel/core": "^7.7.7",

--- a/src/Documentation.md
+++ b/src/Documentation.md
@@ -203,73 +203,57 @@ import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 </DataExplorer>;
 ```
 
-### Custom Styling
+### Custom Controls
 
-You can turn on faceting by sending multiple DataExplorer prop objects to the DataExplorer's `facets` property. When you do so, the properties of each object sent to faceting will be extended onto the properties sent to the data explorer, resulting in multiple views (one for each object sent to `facets`).
+If you pass `OverrideVizControls` to `DataExplorer` you can create your own custom controls for changing metrics. This can allow you to be more deliberate with your controls rather than using the default controls, which are designed for more flexibility. You might want to only expose specific functionality, for instance only allowing a user to add specific features to the chart or look at specific metrics, as below.
 
 ```jsx
+const SampleControls = props => {
+
+const {
+  data,
+  view,
+  chart,
+  metrics,
+  dimensions,
+  selectedDimensions,
+  selectedMetrics,
+  hierarchyType,
+  summaryType,
+  networkType,
+  trendLine,
+  marginalGraphics,
+  barGrouping,
+  updateChart,
+  updateDimensions,
+  setLineType,
+  updateMetrics,
+  generateFacets,
+  lineType,
+  setAreaType,
+  areaType
+} = props
+
+  return <div><button 
+  onClick={() => updateChart({ marginalGraphics: "histogram" })}
+  >Add Marginal Histogram</button>
+  <button
+    onClick={() => updateChart({ chart: { ...chart, metric3: "Generosity" } })}
+  >Show Generosity</button></div>
+}
+
 import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 
 <DataExplorer
   data={{...largeVizData}}
-  overrideSettings={{ size: [150,150], axes: [], oLabel: false, margin: 5 }}
+  OverrideVizControls={SampleControls}
+  overrideSettings={{ size: [400,400], margin: 65 }}
   metadata={{ dx: {
-    facets: [
-    {
-      initialView: "summary",
-      metadata: {
-        dx: {
-          metric1: "Generosity"
-        }
-      }
-    },
-    {
-      initialView: "summary",
-//      dimFacet: { dim: "Region", value: "Western Europe" },
-      metadata: {
-        dx: {
-          metric1: "Dystopia Residual"
-        }
-      }
-    },
-    {
-      initialView: "summary",
-      metadata: {
-        dx: {
-          metric1: "Happiness Score"
-        }
-      }
-    },
-    {
-      initialView: "summary",
-      metadata: {
-        dx: {
-          metric1: "Economy (GDP per Capita)"
-        }
-      }
-    },
-    {
-      initialView: "summary",
-      metadata: {
-        dx: {
-          metric1: "Trust (Government Corruption)"
-        }
-      }
-    },
-    {
-      initialView: "summary",
-      metadata: {
-        dx: {
-          metric1: "Health (Life Expectancy)"
-        }
-      }
-    }
-  ]
-  }
-  } 
-  }
-  initialView="summary"
->
-  <Viz />
-</DataExplorer>;
+    chart: {
+        metric1: "Happiness Score",
+        metric2: "Economy (GDP per Capita)"
+      } 
+    } }}
+  initialView="scatter"
+/>;
 ```

--- a/src/components/DataExplorer.tsx
+++ b/src/components/DataExplorer.tsx
@@ -41,7 +41,7 @@ export interface Props {
         mediaType: Props["mediaType"]
     ) => void;
     overrideSettings?: object;
-    OverrideVizControls?: React.ReactNode
+    OverrideVizControls?: React.ComponentType
 }
 
 interface State {
@@ -567,7 +567,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                 areaType
             }
 
-            const ActualVizControls: React.ReactNode = OverrideVizControls || VizControls
+            const ActualVizControls = OverrideVizControls ? OverrideVizControls : VizControls
 
             finalRenderedViz = <React.Fragment>{instantiatedView}
                 {editable && <ActualVizControls

--- a/src/components/DataExplorer.tsx
+++ b/src/components/DataExplorer.tsx
@@ -41,6 +41,7 @@ export interface Props {
         mediaType: Props["mediaType"]
     ) => void;
     overrideSettings?: object;
+    OverrideVizControls?: React.ReactNode
 }
 
 interface State {
@@ -127,9 +128,9 @@ const MetadataWarningWrapper = styled.div`
 
 const MetadataWarningContent = styled.div`
   & {
-    backgroundcolor: #cce;
+    background: #cce;
     padding: 10px;
-    paddingleft: 20px;
+    padding-left: 20px;
   }
 `;
 
@@ -391,7 +392,7 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
 
         let instantiatedView
 
-        const { data, height } = this.props;
+        const { data, height, OverrideVizControls } = this.props;
 
         const chartKey = generateChartKey({
             view,
@@ -541,31 +542,36 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
                 />
             </FacetWrapper>
         } else {
+
+            const controlProps = {
+                data: stateData,
+                view,
+                chart,
+                metrics,
+                dimensions,
+                selectedDimensions,
+                selectedMetrics,
+                hierarchyType,
+                summaryType,
+                networkType,
+                trendLine,
+                marginalGraphics,
+                barGrouping,
+                updateChart: this.updateChart,
+                updateDimensions: this.updateDimensions,
+                setLineType: this.setLineType,
+                updateMetrics: this.updateMetrics,
+                generateFacets: this.generateFacets,
+                lineType,
+                setAreaType: this.setAreaType,
+                areaType
+            }
+
+            const ActualVizControls: React.ReactNode = OverrideVizControls || VizControls
+
             finalRenderedViz = <React.Fragment>{instantiatedView}
-                {editable && <VizControls
-                    {...{
-                        data: stateData,
-                        view,
-                        chart,
-                        metrics,
-                        dimensions,
-                        selectedDimensions,
-                        selectedMetrics,
-                        hierarchyType,
-                        summaryType,
-                        networkType,
-                        trendLine,
-                        marginalGraphics,
-                        barGrouping,
-                        updateChart: this.updateChart,
-                        updateDimensions: this.updateDimensions,
-                        setLineType: this.setLineType,
-                        updateMetrics: this.updateMetrics,
-                        generateFacets: this.generateFacets,
-                        lineType,
-                        setAreaType: this.setAreaType,
-                        areaType
-                    }} />}</React.Fragment>
+                {editable && <ActualVizControls
+                    {...controlProps} />}</React.Fragment>
         }
 
         const display: React.ReactNode = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     ],
     "resolveJsonModule": true,
     "preserveWatchOutput": true,
+    "allowSyntheticDefaultImports": true,
     "typeRoots": [
       "./node_modules/@types",
       "types"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6031,12 +6031,7 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
-memoize-one@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.0.tgz#fc5e2f1427a216676a62ec652cf7398cfad123db"
-  integrity sha512-wdpOJ4XBejprGn/xhd1i2XR8Dv1A25FJeIvR7syQhQlz9eXsv+06llcvcmBxlWVGv4C73QBsWA8kxvZozzNwiQ==
-
-memoize-one@^5.0.0:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
@@ -8155,10 +8150,10 @@ semiotic-mark@0.4.5:
     d3-selection "^1.4.0"
     d3-transition "^1.2.0"
 
-semiotic@^2.0.0-beta.16:
-  version "2.0.0-rc.0"
-  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-rc.0.tgz#d86a7f53485b96ddd58ff9daa5d6601b9c228d78"
-  integrity sha512-cDa9y8ZQVSuK8bs55uJmlxYnbKZgk7pNSWvjJ8KzokQYFwjgSD5fmQ9bYLTigIiurHD+mOvlP3S0Gxnhu5lPjQ==
+semiotic@^2.0.0-rc.1:
+  version "2.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/semiotic/-/semiotic-2.0.0-rc.1.tgz#ea91091c97330a6138a0247f25a26a05212afd71"
+  integrity sha512-yEDYr8+VUP2d2IuNzDsnzzGZLyRqIWbWR+Zji2ve6eGYxWQUqjXHuRVzJIqAvoJ56SSKQGvIQ39lod1VrJ09lg==
   dependencies:
     d3-array "^1.2.0"
     d3-brush "^1.0.6"
@@ -8178,7 +8173,7 @@ semiotic@^2.0.0-beta.16:
     d3-voronoi "^1.0.2"
     element-resize-event "^3.0.3"
     labella "1.1.4"
-    memoize-one "4.0.0"
+    memoize-one "^5.1.1"
     object-assign "4.1.1"
     polygon-offset "0.3.1"
     react-annotation "3.0.0-beta.4"


### PR DESCRIPTION
This allows people to send `OverrideVizControls` to a `DataExplorer`, which will be sent a host of props and allow them to create custom viz controls. There's an example in the documentation.