### PR TITLE
[bugfix] Update column accessor in Grid component from string property to function accessor.

### DIFF
--- a/src/charts/grid.tsx
+++ b/src/charts/grid.tsx
@@ -180,7 +180,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
       ) {
         return {
           Header: field.name,
-          accessor: field.name,
+          accessor: (rowValue: { [key: string]: any }) => rowValue[field.name],
           fixed: primaryKey.indexOf(field.name) !== -1 && "left",
           filterMethod: (filter: Dx.JSONObject, row: Dx.JSONObject) => {
             if (


### PR DESCRIPTION
## Motivation

Noticed that when my string field name contains a `period`, the grid would be empty, but it would populate if I set the datatype to `any`. This appears to be a quirk with how React-Table works, where dots in field names get turned into attempts to access nested properties within cells that have a type of "object".

https://github.com/tannerlinsley/react-table/issues/1671#issuecomment-574721330

Since this change is in a branch that only affects string/column/number columns, they wouldn't be beneficiaries of the `dot` notation, so it should be safe to replace this string accessor with a function accessor.

## Testing

- See screencap using the basic example from the docs, notice the second column: https://a.cl.ly/o0u6wAqj
- To reproduce: https://codesandbox.io/s/dawn-field-e4mkg?file=/src/App.js
