### PR TITLE
[docs] Add NPM version badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/nteract/examples/master?urlpath=%2Fnteract%2Fedit%2Fpython%2Fhappiness.ipynb)
 [![Node.js CI](https://github.com/nteract/data-explorer/actions/workflows/node.js.yml/badge.svg)](https://github.com/nteract/data-explorer/actions/workflows/node.js.yml)
 [![CodeQL](https://github.com/nteract/data-explorer/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/nteract/data-explorer/actions/workflows/codeql-analysis.yml)
+[![npm version](https://badge.fury.io/js/%40nteract%2Fdata-explorer.svg)](https://www.npmjs.com/package/@nteract/data-explorer)
 
 An automatic data visualization tool.
 


### PR DESCRIPTION
## Motivation

- Avoiding an extra google search when trying to find the NPM download link when starting from the Github page

## Changes

- Add link to NPM lib badge to the README

[![npm version](https://badge.fury.io/js/%40nteract%2Fdata-explorer.svg)](https://www.npmjs.com/package/@nteract/data-explorer)

## Notes

- Created with https://badge.fury.io/for/js
- Other lib badges show information that may be useful for some populations like bundle weight, # of downloads, etc, but latest version is a good place to start.