### PR TITLE
fix: Display table data when there are periods in string column names

### DIFF
--- a/src/charts/grid.tsx
+++ b/src/charts/grid.tsx
@@ -181,6 +181,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
         return {
           Header: field.name,
           accessor: (rowValue: { [key: string]: any }) => rowValue[field.name],
+          id: field.name,
           fixed: primaryKey.indexOf(field.name) !== -1 && "left",
           filterMethod: (filter: Dx.JSONObject, row: Dx.JSONObject) => {
             if (

--- a/src/charts/grid.tsx
+++ b/src/charts/grid.tsx
@@ -180,7 +180,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
       ) {
         return {
           Header: field.name,
-          accessor: field.name,
+          accessor: (rowValue: { [key: string]: any }) => rowValue[field.name],
           fixed: primaryKey.indexOf(field.name) !== -1 && "left",
           filterMethod: (filter: Dx.JSONObject, row: Dx.JSONObject) => {
             if (


### PR DESCRIPTION
## Motivation

- A redo of #41 (reverted b/c of integration test) + a test of whether NPM canary deploys via `auto` are working as intended. Patches adds an extra line to address the integration test that was detected in #55.
- Looked at the Node integration test, realized that a column ID needs to be provided when we use function instead of string accessors (see logs: https://github.com/nteract/data-explorer/runs/2935372040 ).

## Testing

- This is the same change as #41, with an extra line to fix the integration test issue mentioned previously. A preview deploy of the library can be tested using the sample PR link indicated below.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.10--canary.64.d71fcbc.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nteract/data-explorer@8.2.10--canary.64.d71fcbc.0
  # or 
  yarn add @nteract/data-explorer@8.2.10--canary.64.d71fcbc.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
