### PR TITLE
fix: Correctly display complex datatypes (objects) in table cells

### DIFF
--- a/src/charts/grid.tsx
+++ b/src/charts/grid.tsx
@@ -21,6 +21,7 @@ type OnChangeProps = (input: number | string) => void;
 // Only some field types are filterable
 // Iterate over a union type
 // https://stackoverflow.com/a/59420158/5129731
+// Members come from values of Field.type
 const filterableFields= ['integer' , 'number' , 'string'] as const;
 type FilterIndexSignature = typeof filterableFields[number];
 
@@ -156,6 +157,13 @@ function isFilterableFieldType (fieldType: any): fieldType is FilterIndexSignatu
   return filterableFieldSet.has(fieldType);
 }
 
+// Non-primitive field types cannot be outputted directly as React children
+// Members come from possible values of Field.type
+const shouldStringifyFieldSet = new Set([
+  'boolean',
+  'object'
+])
+
 class DataResourceTransformGrid extends React.PureComponent<Props, State> {
   static defaultProps = {
     metadata: {},
@@ -206,8 +214,8 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
           Header: field.name,
           id: field.name,
           accessor: (rowValue: { [key: string]: any }) => {
-            return field.type === "boolean"
-              ? rowValue[field.name].toString()
+            return shouldStringifyFieldSet.has(field.type)
+              ? JSON.stringify(rowValue[field.name])
               : rowValue[field.name];
           },
           fixed: primaryKey.indexOf(field.name) !== -1 && "left",

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -78,7 +78,9 @@ export interface Schema {
 export const defaultPrimaryKey = "dx-default-pk";
 export interface Field {
   name: string;
-  type: string;
+  // Types are based on the json-schema standard, with some variations
+  // https://specs.frictionlessdata.io/table-schema/#types-and-formats
+  type: 'string' | 'integer' | 'number' | 'boolean' | 'datetime' | string; // Other types are permitted, but not explicitly handled
 }
 
 

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -80,7 +80,7 @@ export interface Field {
   name: string;
   // Types are based on the json-schema standard, with some variations
   // https://specs.frictionlessdata.io/table-schema/#types-and-formats
-  type: 'string' | 'integer' | 'number' | 'boolean' | 'datetime' | string; // Other types are permitted, but not explicitly handled
+  type: 'string' | 'integer' | 'number' | 'boolean' | 'datetime' | 'object' | string; // Other types are permitted, but not explicitly handled
 }
 
 


### PR DESCRIPTION
## Motivation

- Fixes #36 
  - Note upstream changes will be needed in the python package that wraps this to set the schema type to `object` instead of `string`.

## Changes

- Assuming that the input schema is typed correctly, stringify object columns before displaying them. (Arrays are a subset of objects). 
- Made Typescript types a bit stricter to guard against this type of issue in the future: https://github.com/nteract/data-explorer/pull/65/commits/64f9565ec9f7099883e1f19f5bba5cfe82f9b0ec

## Testing

- Before: https://codesandbox.io/s/pedantic-hodgkin-78o80?file=/src/App.js:216-221, outputs error message. [Screenshot](https://a.cl.ly/Kou4jpdk)
- After: https://codesandbox.io/s/priceless-goldwasser-bdfkn?file=/src/App.js, renders object inside table cell [Screenshot](https://a.cl.ly/kpuD80Kg)

## Future steps

- [x] look into setting up unit rendering tests on a per-component basis so errors like this can be detected in a more automated fashion (vs comparing codesandbox before and after) (Update: filed an issue: https://github.com/nteract/data-explorer/issues/67 )
- [x] Quality of life: we can run pre-commit style hooks on git commit (perhaps use Husky + prettier hooks). (Update: provided in https://github.com/nteract/data-explorer/pull/66 )

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.10--canary.65.4b3f411.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nteract/data-explorer@8.2.10--canary.65.4b3f411.0
  # or 
  yarn add @nteract/data-explorer@8.2.10--canary.65.4b3f411.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
