### PR TITLE
chore: apply eslint + prettier auto-fixes to whole codebase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,9 @@ module.exports = {
     sourceType: "module",
   },
   plugins: ["@typescript-eslint"],
-  rules: {},
+  rules: {
+    "no-unused-vars": "warn",
+  },
   overrides: [
     {
       // No need to check for global definitions in Eslint, let Typescript compiler handle it.

--- a/src/Documentation.md
+++ b/src/Documentation.md
@@ -30,28 +30,28 @@ const basicData = {
     fields: [
       {
         name: "valueA",
-        type: "integer"
+        type: "integer",
       },
       {
         name: "valueB",
-        type: "integer"
+        type: "integer",
       },
       {
         name: "valueC",
-        type: "integer"
+        type: "integer",
       },
       {
         name: "label",
-        type: "string"
-      }
+        type: "string",
+      },
     ],
-    primaryKey: []
+    primaryKey: [],
   },
   data: [
     { valueA: 3, valueB: 5, valueC: 1, label: "first" },
     { valueA: 10, valueB: 1, valueC: 12, label: "second" },
-    { valueA: -5, valueB: 8, valueC: 6, label: "third" }
-  ]
+    { valueA: -5, valueB: 8, valueC: 6, label: "third" },
+  ],
 };
 
 <DataExplorer data={basicData} />;
@@ -66,13 +66,13 @@ Chart settings refer to the metrics, dimensions and sort order for time series d
 import DataExplorer from "@nteract/data-explorer";
 
 <DataExplorer
-overrideSettings={{
-        backgroundGraphics: <text
-          fontSize="24px"
-          fontWeight={900}
-          fill="#DDD"
-          y={20}>DX™</text>
-      }}
+  overrideSettings={{
+    backgroundGraphics: (
+      <text fontSize="24px" fontWeight={900} fill="#DDD" y={20}>
+        DX™
+      </text>
+    ),
+  }}
   data={largeVizData}
   initialView="summary"
   metadata={{
@@ -86,12 +86,12 @@ overrideSettings={{
         "rgb(62,142,157)",
         "rgb(145,206,244)",
         "rgb(28,75,180)",
-        "rgb(82,233,230)"
+        "rgb(82,233,230)",
       ],
       chart: {
-        metric1: "Happiness Score"
-      }
-    }
+        metric1: "Happiness Score",
+      },
+    },
   }}
 />;
 ```
@@ -125,8 +125,8 @@ import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
   metadata={{
     dx: {
       hierarchyType: "treemap",
-      metric1: "Economy (GDP per Capita)"
-    }
+      metric1: "Economy (GDP per Capita)",
+    },
   }}
 >
   <Viz />
@@ -141,62 +141,62 @@ You can turn on faceting by sending multiple DataExplorer prop objects to the Da
 import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 
 <DataExplorer
-  data={{...largeVizData}}
-  metadata={{ dx: {
-    facets: [
-    {
-      initialView: "bar",
-      metadata: {
-        dx: {
-          metric1: "Generosity"
-        }
-      }
+  data={{ ...largeVizData }}
+  metadata={{
+    dx: {
+      facets: [
+        {
+          initialView: "bar",
+          metadata: {
+            dx: {
+              metric1: "Generosity",
+            },
+          },
+        },
+        {
+          initialView: "bar",
+          //      dimFacet: { dim: "Region", value: "Western Europe" },
+          metadata: {
+            dx: {
+              metric1: "Dystopia Residual",
+            },
+          },
+        },
+        {
+          initialView: "bar",
+          metadata: {
+            dx: {
+              metric1: "Happiness Score",
+            },
+          },
+        },
+        {
+          initialView: "bar",
+          metadata: {
+            dx: {
+              metric1: "Economy (GDP per Capita)",
+            },
+          },
+        },
+        {
+          initialView: "bar",
+          metadata: {
+            dx: {
+              metric1: "Trust (Government Corruption)",
+            },
+          },
+        },
+        {
+          initialView: "bar",
+          metadata: {
+            dx: {
+              metric1: "Health (Life Expectancy)",
+            },
+          },
+        },
+      ],
     },
-    {
-      initialView: "bar",
-//      dimFacet: { dim: "Region", value: "Western Europe" },
-      metadata: {
-        dx: {
-          metric1: "Dystopia Residual"
-        }
-      }
-    },
-    {
-      initialView: "bar",
-      metadata: {
-        dx: {
-          metric1: "Happiness Score"
-        }
-      }
-    },
-    {
-      initialView: "bar",
-      metadata: {
-        dx: {
-          metric1: "Economy (GDP per Capita)"
-        }
-      }
-    },
-    {
-      initialView: "bar",
-      metadata: {
-        dx: {
-          metric1: "Trust (Government Corruption)"
-        }
-      }
-    },
-    {
-      initialView: "bar",
-      metadata: {
-        dx: {
-          metric1: "Health (Life Expectancy)"
-        }
-      }
-    }
-  ]
-  }
-  } 
-  }
+  }}
   initialView="summary"
 >
   <Viz />
@@ -208,52 +208,61 @@ import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 If you pass `OverrideVizControls` to `DataExplorer` you can create your own custom controls for changing metrics. This can allow you to be more deliberate with your controls rather than using the default controls, which are designed for more flexibility. You might want to only expose specific functionality, for instance only allowing a user to add specific features to the chart or look at specific metrics, as below.
 
 ```jsx
-const SampleControls = props => {
+const SampleControls = (props) => {
+  const {
+    data,
+    view,
+    chart,
+    metrics,
+    dimensions,
+    selectedDimensions,
+    selectedMetrics,
+    hierarchyType,
+    summaryType,
+    networkType,
+    trendLine,
+    marginalGraphics,
+    barGrouping,
+    updateChart,
+    updateDimensions,
+    setLineType,
+    updateMetrics,
+    generateFacets,
+    lineType,
+    setAreaType,
+    areaType,
+  } = props;
 
-const {
-  data,
-  view,
-  chart,
-  metrics,
-  dimensions,
-  selectedDimensions,
-  selectedMetrics,
-  hierarchyType,
-  summaryType,
-  networkType,
-  trendLine,
-  marginalGraphics,
-  barGrouping,
-  updateChart,
-  updateDimensions,
-  setLineType,
-  updateMetrics,
-  generateFacets,
-  lineType,
-  setAreaType,
-  areaType
-} = props
-
-  return <div><button 
-  onClick={() => updateChart({ marginalGraphics: "histogram" })}
-  >Add Marginal Histogram</button>
-  <button
-    onClick={() => updateChart({ chart: { ...chart, metric3: "Generosity" } })}
-  >Show Generosity</button></div>
-}
+  return (
+    <div>
+      <button onClick={() => updateChart({ marginalGraphics: "histogram" })}>
+        Add Marginal Histogram
+      </button>
+      <button
+        onClick={() =>
+          updateChart({ chart: { ...chart, metric3: "Generosity" } })
+        }
+      >
+        Show Generosity
+      </button>
+    </div>
+  );
+};
 
 import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 
 <DataExplorer
-  data={{...largeVizData}}
+  data={{ ...largeVizData }}
   OverrideVizControls={SampleControls}
-  overrideSettings={{ size: [400,400], margin: 65 }}
-  metadata={{ dx: {
-    chart: {
+  overrideSettings={{ size: [400, 400], margin: 65 }}
+  metadata={{
+    dx: {
+      chart: {
         metric1: "Happiness Score",
-        metric2: "Economy (GDP per Capita)"
-      } 
-    } }}
+        metric2: "Economy (GDP per Capita)",
+      },
+    },
+  }}
   initialView="scatter"
 />;
 ```
@@ -263,84 +272,106 @@ import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 If you pass `additionalViews` an object with keys corresponding to your view name (you can override existing view names or create your own) that has properties `Frame: ReactNode, controls: string, chartGenerator: Function => propsForReactNode, FacetFrame: ReactNode` you can create your own views.
 
 ```jsx
+const BigNumberDiv = (props) => {
+  const { bigAverage, bigTrend } = props;
+  const { metricAverage, metrics } = props;
 
-const BigNumberDiv = props => {
-  const { bigAverage, bigTrend } = props
-  const { metricAverage, metrics } = props
+  return metrics.map((d, i) => {
+    const diff = d.value - metricAverage;
 
-  return metrics.map((d,i) => {
-
-    const diff = d.value - metricAverage
-    
-    return <div key={d.label} style={{ textAlign: "center", width: "100px", border: "1px solid black",
-  borderRadius: "5px", margin: "10px", padding: "10px",
-  display: "inline-block" }}>
-  <h3>{d.label}</h3>
-  <h2>{d.value.toFixed(2)}</h2>
-  <h1 style={{ color: diff > 0 ? "darkgreen" : "darkred" }}>
-  {diff > 0 ? "+" : ""}{diff.toFixed(2)}</h1>
-  </div>} )
-}
+    return (
+      <div
+        key={d.label}
+        style={{
+          textAlign: "center",
+          width: "100px",
+          border: "1px solid black",
+          borderRadius: "5px",
+          margin: "10px",
+          padding: "10px",
+          display: "inline-block",
+        }}
+      >
+        <h3>{d.label}</h3>
+        <h2>{d.value.toFixed(2)}</h2>
+        <h1 style={{ color: diff > 0 ? "darkgreen" : "darkred" }}>
+          {diff > 0 ? "+" : ""}
+          {diff.toFixed(2)}
+        </h1>
+      </div>
+    );
+  });
+};
 
 const createBigNumber = (stateData, schema, chartSettings) => {
+  const {
+    chart: { metric1 },
+  } = chartSettings;
 
-  const { chart: { metric1 } } = chartSettings
+  const metrics = stateData
+    .map((d) => {
+      const label = d.Country;
+      const value = d[metric1];
 
-  const metrics = stateData.map(d => {
-    const label = d.Country
-    const value = d[metric1]
+      return {
+        label,
+        value,
+      };
+    })
+    .sort((a, b) => b.value - a.value)
+    .filter((d, i) => i < 12);
 
-    return {
-      label,
-      value
-    }
-  } )
-  .sort((a,b) => b.value - a.value)
-  .filter((d,i) => i < 12)
-
-  const metricAverage = (metrics.reduce((p,c)=> p += c.value,0) / 12)
+  const metricAverage = metrics.reduce((p, c) => (p += c.value), 0) / 12;
 
   return {
     frameSettings: {
       metricAverage,
-      metrics
+      metrics,
     },
     //For facets sharing the same styling
     colorDim: "none",
-    colorHash: {}
-  }
-}
+    colorHash: {},
+  };
+};
 
 const generateBigNumber = {
   Frame: BigNumberDiv,
   controls: "switch between modes",
   chartGenerator: createBigNumber,
-  FacetFrame: BigNumberDiv
-}
+  FacetFrame: BigNumberDiv,
+};
 
 const additionalViews = {
-  bignumber: generateBigNumber
-}
+  bignumber: generateBigNumber,
+};
 
-const SampleControls = props => {
+const SampleControls = (props) => {
+  const { updateChart, chart } = props;
 
-const {
-  updateChart,
-  chart
-} = props
-
-  return <div><button 
-    onClick={() => updateChart({ chart: { ...chart, metric1: "Happiness Score" } })}
-  >Show Happiness Score</button>
-  <button
-    onClick={() => updateChart({ chart: { ...chart, metric1: "Generosity" } })}
-  >Show Generosity</button></div>
-}
+  return (
+    <div>
+      <button
+        onClick={() =>
+          updateChart({ chart: { ...chart, metric1: "Happiness Score" } })
+        }
+      >
+        Show Happiness Score
+      </button>
+      <button
+        onClick={() =>
+          updateChart({ chart: { ...chart, metric1: "Generosity" } })
+        }
+      >
+        Show Generosity
+      </button>
+    </div>
+  );
+};
 
 import DataExplorer, { Viz, Toolbar } from "@nteract/data-explorer";
 
 <DataExplorer
-  data={{...largeVizData}}
+  data={{ ...largeVizData }}
   OverrideVizControls={SampleControls}
   initialView="bignumber"
   additionalViews={additionalViews}

--- a/src/chartmeta/chart-docs.ts
+++ b/src/chartmeta/chart-docs.ts
@@ -1,6 +1,5 @@
 export const chartHelpText = {
-  line:
-    "Line and stacked area charts for time series data where each row is a point and columns are data to be plotted.",
+  line: "Line and stacked area charts for time series data where each row is a point and columns are data to be plotted.",
   bar: "Bar charts to compare individual and aggregate amounts.",
   scatter: "Scatterplot for comparing correlation between x and y values.",
   grid: "A table of data.",
@@ -12,7 +11,7 @@ export const chartHelpText = {
   parallel:
     "Parallel coordinates for comparing and filtering across different values in the dataset.",
   hierarchy:
-    "Nest data by categorical values using treemap, dendrogram, sunburst or partition."
+    "Nest data by categorical values using treemap, dendrogram, sunburst or partition.",
 };
 
 const hexScatterX = "Plot this metric along the X axis";
@@ -42,32 +41,32 @@ export type ExplorationTypes =
   | "barGrouping"
   | "marginalGraphics";
 export const controlHelpText: {
-  [key in ExplorationTypes]?: { [key: string]: string } | string
+  [key in ExplorationTypes]?: { [key: string]: string } | string;
 } = {
   metric1: {
     default: "Plot this metric",
     scatter: hexScatterX,
-    hexbin: hexScatterX
+    hexbin: hexScatterX,
   },
   metric2: {
-    default: "Plot this metric along the Y axis"
+    default: "Plot this metric along the Y axis",
   },
   metric3: {
     default: "Size the width of bars (Marimekko style) based on this metric",
-    scatter: "Size the radius of points based on this metric"
+    scatter: "Size the radius of points based on this metric",
   },
   metric4: "Error bars according to this value",
   dim1: {
     default: "Color items by this dimension",
     summary: "Group items into this category",
-    network: "Use this dimension to determine the source node"
+    network: "Use this dimension to determine the source node",
   },
   dim2: {
     default: "Label prominent datapoints using this dimension",
-    network: "Use this dimension to determine the target node"
+    network: "Use this dimension to determine the target node",
   },
   dim3: {
-    default: "Split contours into separate groups based on this dimension"
+    default: "Split contours into separate groups based on this dimension",
   },
   networkType:
     "Represent network as a force-directed network (good for social networks) or as a sankey diagram (good for flow networks)",
@@ -84,5 +83,5 @@ export const controlHelpText: {
   barGrouping:
     "Choose between a clustered or a stacked bar chart when there are multiple pieces in the same category",
   marginalGraphics:
-    "Choose the kind of marginal summary you want to see for summarizing density along the axes"
+    "Choose the kind of marginal summary you want to see for summarizing density along the axes",
 };

--- a/src/charts/bar.tsx
+++ b/src/charts/bar.tsx
@@ -1,20 +1,20 @@
-import * as React from "react"
+import * as React from "react";
 
-import HTMLLegend from "../components/HTMLLegend"
-import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content"
-import { numeralFormatting } from "../utilities/utilities"
+import HTMLLegend from "../components/HTMLLegend";
+import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content";
+import { numeralFormatting } from "../utilities/utilities";
 
-import * as Dx from "../utilities/types"
-import { sortByOrdinalRange } from "./shared"
+import * as Dx from "../utilities/types";
+import { sortByOrdinalRange } from "./shared";
 
 interface BarOptions {
-  selectedDimensions: string[]
-  chart: Dx.Chart
-  colors: string[]
-  setColor: (color: string[]) => void
-  barGrouping: Dx.BarGroupingType
-  dimensions: Dx.Dimension[]
-  metrics: Dx.Metric[]
+  selectedDimensions: string[];
+  chart: Dx.Chart;
+  colors: string[];
+  setColor: (color: string[]) => void;
+  barGrouping: Dx.BarGroupingType;
+  dimensions: Dx.Dimension[];
+  metrics: Dx.Metric[];
 }
 
 export const semioticBarChart = (
@@ -22,65 +22,65 @@ export const semioticBarChart = (
   schema: Dx.Schema,
   options: BarOptions,
   colorHashOverride?: any,
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
-  const { selectedDimensions, chart, colors, setColor, barGrouping } = options
-  const { dim1, metric1, metric3, metric4 } = chart
+  const { selectedDimensions, chart, colors, setColor, barGrouping } = options;
+  const { dim1, metric1, metric3, metric4 } = chart;
 
   const oAccessor =
     selectedDimensions.length === 0
       ? dim1
       : (datapoint: Dx.Datapoint) =>
           selectedDimensions
-            .map(selectedDim => datapoint[selectedDim])
-            .join(",")
+            .map((selectedDim) => datapoint[selectedDim])
+            .join(",");
 
-  const rAccessor = metric1
+  const rAccessor = metric1;
 
   const additionalSettings: {
-    afterElements?: JSX.Element
-    dynamicColumnWidth?: string
-    rExtent?: number[]
+    afterElements?: JSX.Element;
+    dynamicColumnWidth?: string;
+    rExtent?: number[];
     tooltipContent?: (hoveredDataPoint: {
-      x: number
-      y: number
-      [key: string]: any
-    }) => JSX.Element
-    pieceHoverAnnotation?: boolean
-  } = {}
+      x: number;
+      y: number;
+      [key: string]: any;
+    }) => JSX.Element;
+    pieceHoverAnnotation?: boolean;
+  } = {};
 
-  const colorHash = colorHashOverride || { Other: "grey" }
+  const colorHash = colorHashOverride || { Other: "grey" };
 
   const sortedData = sortByOrdinalRange(
     oAccessor,
     (metric3 !== "none" && metric3) || rAccessor,
     dim1,
-    data
-  )
+    data,
+  );
 
   if (metric3 && metric3 !== "none") {
-    additionalSettings.dynamicColumnWidth = metric3
+    additionalSettings.dynamicColumnWidth = metric3;
   }
-  let errorBarAnnotations
+  let errorBarAnnotations;
   if (barGrouping === "Clustered" && metric4 && metric4 !== "none") {
     additionalSettings.rExtent = [
-      Math.min(...data.map(d => d[metric1] - d[metric4])),
-      Math.max(...data.map(d => d[metric1] + d[metric4]))
-    ]
+      Math.min(...data.map((d) => d[metric1] - d[metric4])),
+      Math.max(...data.map((d) => d[metric1] + d[metric4])),
+    ];
 
     errorBarAnnotations = (
       d: Dx.Datapoint,
       i: number,
       xy: {
-        width: number
-        height: number
-        styleFn: (args: object) => object
-        rScale: (args: object) => number
-      }
+        width: number;
+        height: number;
+        styleFn: (args: object) => object;
+        rScale: (args: object) => number;
+      },
     ) => {
       const errorBarSize = Math.abs(
-        xy.rScale(d[metric1]) - xy.rScale(d[metric1] + d[metric4])
-      )
+        xy.rScale(d[metric1]) - xy.rScale(d[metric1] + d[metric4]),
+      );
 
       return (
         <g>
@@ -108,25 +108,25 @@ export const semioticBarChart = (
             />
           </g>
         </g>
-      )
-    }
+      );
+    };
   }
 
   const uniqueValues = sortedData.reduce(
     (uniques, datapoint) =>
       !uniques.find(
-        (uniqueDimName: string) => uniqueDimName === datapoint[dim1].toString()
+        (uniqueDimName: string) => uniqueDimName === datapoint[dim1].toString(),
       )
         ? [...uniques, datapoint[dim1].toString()]
         : uniques,
-    []
-  )
+    [],
+  );
 
   if (!colorHashOverride && dim1 && dim1 !== "none") {
     uniqueValues.forEach((value: string, index: number) => {
       // Color the first 18 values after that everything gets grey because more than 18 colors is unreadable no matter what you want
-      colorHash[value] = index > 18 ? "grey" : colors[index % colors.length]
-    })
+      colorHash[value] = index > 18 ? "grey" : colors[index % colors.length];
+    });
 
     additionalSettings.afterElements = (
       <HTMLLegend
@@ -135,14 +135,14 @@ export const semioticBarChart = (
         setColor={setColor}
         colors={colors}
       />
-    )
+    );
 
     if (
       barGrouping === "Clustered" ||
       (selectedDimensions.length > 0 && selectedDimensions.join(",") !== dim1)
     ) {
-      additionalSettings.pieceHoverAnnotation = true
-      additionalSettings.tooltipContent = hoveredDatapoint => {
+      additionalSettings.pieceHoverAnnotation = true;
+      additionalSettings.tooltipContent = (hoveredDatapoint) => {
         return (
           <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
             <div style={{ display: "flex", flexWrap: "wrap" }}>
@@ -153,14 +153,14 @@ export const semioticBarChart = (
                       style={{
                         margin: "2px 5px 0",
                         display: "inline-block",
-                        minWidth: "100px"
+                        minWidth: "100px",
                       }}
                       key={`dim-${index}`}
                     >
                       <span style={{ fontWeight: 600 }}>{dim.name}</span>:{" "}
                       {safeDisplayValue(hoveredDatapoint[dim.name])}
                     </div>
-                  )
+                  );
                 })}
               </div>
               <div>
@@ -169,7 +169,7 @@ export const semioticBarChart = (
                     style={{
                       margin: "2px 5px 0",
                       display: "inline-block",
-                      minWidth: "100px"
+                      minWidth: "100px",
                     }}
                     key={`dim-${index}`}
                   >
@@ -180,8 +180,8 @@ export const semioticBarChart = (
               </div>
             </div>
           </TooltipContent>
-        )
-      }
+        );
+      };
     }
   }
 
@@ -195,14 +195,14 @@ export const semioticBarChart = (
     rAccessor,
     style: (datapoint: Dx.Datapoint) => ({
       fill: colorHash[datapoint[colorDimOverride || dim1]] || colors[0],
-      stroke: colorHash[datapoint[colorDimOverride || dim1]] || colors[0]
+      stroke: colorHash[datapoint[colorDimOverride || dim1]] || colors[0],
     }),
     oPadding: uniqueValues.length > 30 ? 1 : 5,
     oLabel:
       uniqueValues.length > 30
         ? false
         : (columnLabel: object) => {
-            return <text transform="rotate(90)">{columnLabel}</text>
+            return <text transform="rotate(90)">{columnLabel}</text>;
           },
     hoverAnnotation: true,
     margin: { top: 10, right: 10, bottom: 100, left: 70 },
@@ -210,8 +210,8 @@ export const semioticBarChart = (
       {
         orient: "left",
         label: rAccessor,
-        tickFormat: numeralFormatting
-      }
+        tickFormat: numeralFormatting,
+      },
     ],
     tooltipContent: (hoveredDatapoint: { [key: string]: any }) => {
       return (
@@ -239,12 +239,12 @@ export const semioticBarChart = (
             </p>
           )}
         </TooltipContent>
-      )
+      );
     },
     baseMarkProps: { forceUpdate: true },
     size: [500, 600],
-    ...additionalSettings
-  }
+    ...additionalSettings,
+  };
 
-  return { frameSettings: barSettings, colorDim: dim1, colorHash }
-}
+  return { frameSettings: barSettings, colorDim: dim1, colorHash };
+};

--- a/src/charts/grid.tsx
+++ b/src/charts/grid.tsx
@@ -11,7 +11,7 @@ const switchMode = (currentMode: string) => {
   const nextMode: Dx.JSONObject = {
     "=": ">",
     ">": "<",
-    "<": "="
+    "<": "=",
   };
   return nextMode[currentMode];
 };
@@ -22,7 +22,7 @@ type OnChangeProps = (input: number | string) => void;
 // Iterate over a union type
 // https://stackoverflow.com/a/59420158/5129731
 // Members come from values of Field.type
-const filterableFields= ['integer' , 'number' , 'string'] as const;
+const filterableFields = ["integer", "number", "string"] as const;
 type FilterIndexSignature = typeof filterableFields[number];
 
 interface NumberFilterProps {
@@ -42,7 +42,7 @@ const NumberFilter = (props: NumberFilterProps) => {
         border: "1px solid gray",
         background: "white",
         borderRadius: "5px",
-        width: "100%"
+        width: "100%",
       }}
     >
       <input
@@ -66,47 +66,52 @@ const NumberFilter = (props: NumberFilterProps) => {
   );
 };
 
-const stringFilter = () => ({ onChange }: { onChange: OnChangeProps }) => (
-  <form>
-    <input
-      type="text"
-      id="string-filter"
-      name="string-filter"
-      onChange={(event: React.FormEvent<HTMLInputElement>) => {
-        onChange(event.currentTarget.value);
-      }}
-      placeholder="string"
-    />
-  </form>
-);
+const stringFilter =
+  () =>
+  ({ onChange }: { onChange: OnChangeProps }) =>
+    (
+      <form>
+        <input
+          type="text"
+          id="string-filter"
+          name="string-filter"
+          onChange={(event: React.FormEvent<HTMLInputElement>) => {
+            onChange(event.currentTarget.value);
+          }}
+          placeholder="string"
+        />
+      </form>
+    );
 
-const numberFilterWrapper = (
-  filterState: NumberFilterProps["filterState"],
-  filterName: NumberFilterProps["filterName"],
-  updateFunction: NumberFilterProps["updateFunction"]
-) => ({ onChange }: { onChange: OnChangeProps }) => (
-  <NumberFilter
-    onChange={onChange}
-    filterState={filterState}
-    filterName={filterName}
-    updateFunction={updateFunction}
-  />
-);
+const numberFilterWrapper =
+  (
+    filterState: NumberFilterProps["filterState"],
+    filterName: NumberFilterProps["filterName"],
+    updateFunction: NumberFilterProps["updateFunction"],
+  ) =>
+  ({ onChange }: { onChange: OnChangeProps }) =>
+    (
+      <NumberFilter
+        onChange={onChange}
+        filterState={filterState}
+        filterName={filterName}
+        updateFunction={updateFunction}
+      />
+    );
 
-const filterNumbers = (mode = "=") => (
-  filter: FilterObject,
-  row: NumberRowObject
-) => {
-  const filterValue = Number(filter.value);
-  if (mode === "=") {
-    return row[filter.id] === filterValue;
-  } else if (mode === "<") {
-    return row[filter.id] < filterValue;
-  } else if (mode === ">") {
-    return row[filter.id] > filterValue;
-  }
-  return row[filter.id];
-};
+const filterNumbers =
+  (mode = "=") =>
+  (filter: FilterObject, row: NumberRowObject) => {
+    const filterValue = Number(filter.value);
+    if (mode === "=") {
+      return row[filter.id] === filterValue;
+    } else if (mode === "<") {
+      return row[filter.id] < filterValue;
+    } else if (mode === ">") {
+      return row[filter.id] > filterValue;
+    }
+    return row[filter.id];
+  };
 
 const filterStrings = () => (filter: FilterObject, row: StringRowObject) => {
   return (
@@ -119,13 +124,13 @@ type FilterMethodType = { [index in FilterIndexSignature]: Function };
 const columnFilters: FilterMethodType = {
   integer: numberFilterWrapper,
   number: numberFilterWrapper,
-  string: stringFilter
+  string: stringFilter,
 };
 
 const filterMethod: FilterMethodType = {
   integer: filterNumbers,
   number: filterNumbers,
-  string: filterStrings
+  string: filterStrings,
 };
 
 interface FilterObject {
@@ -153,28 +158,27 @@ interface Props {
 }
 
 const filterableFieldSet = new Set(filterableFields);
-function isFilterableFieldType (fieldType: any): fieldType is FilterIndexSignature {
+function isFilterableFieldType(
+  fieldType: any,
+): fieldType is FilterIndexSignature {
   return filterableFieldSet.has(fieldType);
 }
 
 // Non-primitive field types cannot be outputted directly as React children
 // Members come from possible values of Field.type
-const shouldStringifyFieldSet = new Set([
-  'boolean',
-  'object'
-])
+const shouldStringifyFieldSet = new Set(["boolean", "object"]);
 
 class DataResourceTransformGrid extends React.PureComponent<Props, State> {
   static defaultProps = {
     metadata: {},
-    height: 500
+    height: 500,
   };
 
   constructor(props: Props) {
     super(props);
     this.state = {
       filters: {},
-      showFilters: false
+      showFilters: false,
     };
   }
 
@@ -182,7 +186,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
     const {
       data: { data, schema },
       height,
-      theme
+      theme,
     } = this.props;
 
     const { filters, showFilters } = this.state;
@@ -236,7 +240,7 @@ class DataResourceTransformGrid extends React.PureComponent<Props, State> {
           data={data}
           columns={tableColumns}
           style={{
-            height: `${height}px`
+            height: `${height}px`,
           }}
           className="-striped -highlight"
           filterable={showFilters}

--- a/src/charts/hierarchical.tsx
+++ b/src/charts/hierarchical.tsx
@@ -1,208 +1,209 @@
-import { nest } from "d3-collection"
-import { interpolateLab } from "d3-interpolate"
-import * as React from "react"
+import { nest } from "d3-collection";
+import { interpolateLab } from "d3-interpolate";
+import * as React from "react";
 
-import TooltipContent from "../utilities/tooltip-content"
+import TooltipContent from "../utilities/tooltip-content";
 
-import * as Dx from "../utilities/types"
+import * as Dx from "../utilities/types";
 
 interface HierarchicalOptions {
-  hierarchyType: Dx.HierarchyType
-  chart: Dx.Chart
-  selectedDimensions: Dx.ChartOptions["selectedDimensions"]
-  primaryKey: Dx.ChartOptions["primaryKey"]
-  colors: Dx.ChartOptions["colors"]
+  hierarchyType: Dx.HierarchyType;
+  chart: Dx.Chart;
+  selectedDimensions: Dx.ChartOptions["selectedDimensions"];
+  primaryKey: Dx.ChartOptions["primaryKey"];
+  colors: Dx.ChartOptions["colors"];
 }
 
-const overrideFrameHover = (hierarchyType: Dx.HierarchyType) => (
-  annotation: any
-) => {
-  const { d } = annotation
-  if (d.type === "frame-hover" && hierarchyType !== "treemap") {
-    return
-  }
-  return null
-}
+const overrideFrameHover =
+  (hierarchyType: Dx.HierarchyType) => (annotation: any) => {
+    const { d } = annotation;
+    if (d.type === "frame-hover" && hierarchyType !== "treemap") {
+      return;
+    }
+    return null;
+  };
 
-const hierarchicalAnnotation = (
-  hierarchyType: Dx.HierarchyType,
-  selectedDimensions: string[],
-  metric: string
-) => (annotation: any) => {
-  const { d, networkFrameState, nodes: drawnNodes } = annotation
-  const { type, parent } = d
-  const { networkFrameRender } = networkFrameState
+const hierarchicalAnnotation =
+  (
+    hierarchyType: Dx.HierarchyType,
+    selectedDimensions: string[],
+    metric: string,
+  ) =>
+  (annotation: any) => {
+    const { d, networkFrameState, nodes: drawnNodes } = annotation;
+    const { type, parent } = d;
+    const { networkFrameRender } = networkFrameState;
 
-  if (hierarchyType !== "treemap" && parent && type === "highlight") {
-    const { nodes } = networkFrameRender
-    const { customMark, styleFn: baseStyle } = nodes
+    if (hierarchyType !== "treemap" && parent && type === "highlight") {
+      const { nodes } = networkFrameRender;
+      const { customMark, styleFn: baseStyle } = nodes;
 
-    const ancestors = parent.ancestors()
-    const parentPlusPieces = [parent, ...ancestors]
+      const ancestors = parent.ancestors();
+      const parentPlusPieces = [parent, ...ancestors];
 
-    const drawnPieces = parentPlusPieces.map(d =>
-      drawnNodes.find(
-        (p: any) =>
-          (p.depth === 0 && d.depth === 0) ||
-          p.hierarchicalID === d.hierarchicalID
-      )
-    )
+      const drawnPieces = parentPlusPieces.map((d) =>
+        drawnNodes.find(
+          (p: any) =>
+            (p.depth === 0 && d.depth === 0) ||
+            p.hierarchicalID === d.hierarchicalID,
+        ),
+      );
 
-    const allPieces = [d, ...drawnPieces]
-    const baseMarkProps = { forceUpdate: true }
+      const allPieces = [d, ...drawnPieces];
+      const baseMarkProps = { forceUpdate: true };
 
-    const ancestorHighlight = allPieces.map((node, nodei) => {
-      const transform = `translate(${node.x},${node.y})`
-      const styleFn = (d: any) => ({
-        ...baseStyle(d),
-        ...{ fill: "red", opacity: 0.5, stroke: "red", strokeWidth: "4px" }
-      })
-      const customNode = customMark({
-        d: node,
-        styleFn,
-        transform: transform,
-        baseMarkProps,
-        key: `highlight-${nodei}-parent`
-      })
+      const ancestorHighlight = allPieces.map((node, nodei) => {
+        const transform = `translate(${node.x},${node.y})`;
+        const styleFn = (d: any) => ({
+          ...baseStyle(d),
+          ...{ fill: "red", opacity: 0.5, stroke: "red", strokeWidth: "4px" },
+        });
+        const customNode = customMark({
+          d: node,
+          styleFn,
+          transform: transform,
+          baseMarkProps,
+          key: `highlight-${nodei}-parent`,
+        });
 
-      const thisLevelName = selectedDimensions[node.depth - 1]
+        const thisLevelName = selectedDimensions[node.depth - 1];
 
-      return (
-        <g>
-          {customNode}
-          <text transform={transform}>
-            {thisLevelName && `${thisLevelName}: ${node.key}`}
-            {node.depth !== 0 && node[metric] && `${metric}: ${node[metric]}`}
-          </text>
-        </g>
-      )
-    })
-    return <g>{ancestorHighlight}</g>
-  }
-  return null
-}
+        return (
+          <g>
+            {customNode}
+            <text transform={transform}>
+              {thisLevelName && `${thisLevelName}: ${node.key}`}
+              {node.depth !== 0 && node[metric] && `${metric}: ${node[metric]}`}
+            </text>
+          </g>
+        );
+      });
+      return <g>{ancestorHighlight}</g>;
+    }
+    return null;
+  };
 
 const parentPath = (datapoint: Dx.Datapoint, pathArray: string[]) => {
   if (datapoint.parent) {
-    pathArray = parentPath(datapoint.parent, [datapoint.key, ...pathArray])
+    pathArray = parentPath(datapoint.parent, [datapoint.key, ...pathArray]);
   } else {
-    pathArray = [...pathArray]
+    pathArray = [...pathArray];
   }
-  return pathArray
-}
+  return pathArray;
+};
 
 const hierarchicalTooltip = (
   datapoint: Dx.Datapoint,
   primaryKey: string[],
   metric: string,
-  selectedDimensions: string[]
+  selectedDimensions: string[],
 ) => {
   const pathString = datapoint.parent
     ? parentPath(
         datapoint.parent,
-        (datapoint.key && [datapoint.key]) || []
+        (datapoint.key && [datapoint.key]) || [],
       ).map((d, i) => (
         <p>
           {selectedDimensions[i]}: {d}
         </p>
       ))
-    : ""
-  const content = []
+    : "";
+  const content = [];
   if (!datapoint.parent) {
-    content.push(<h2 key="hierarchy-title">Root</h2>)
+    content.push(<h2 key="hierarchy-title">Root</h2>);
   } else if (datapoint.key) {
-    content.push(<h2 key="hierarchy-title">{datapoint.key}</h2>)
-    content.push(<p key="path-string">{pathString}</p>)
-    content.push(<p key="hierarchy-value">Total Value: {datapoint.value}</p>)
+    content.push(<h2 key="hierarchy-title">{datapoint.key}</h2>);
+    content.push(<p key="path-string">{pathString}</p>);
+    content.push(<p key="hierarchy-value">Total Value: {datapoint.value}</p>);
     content.push(
-      <p key="hierarchy-children">Children: {datapoint.children.length}</p>
-    )
+      <p key="hierarchy-children">Children: {datapoint.children.length}</p>,
+    );
   } else {
     content.push(
       pathString,
       <p key="leaf-label">
         {primaryKey.map((pkey: string) => datapoint[pkey]).join(", ")}
-      </p>
-    )
+      </p>,
+    );
     content.push(
       <p key="hierarchy-value">
         {metric}: {datapoint[metric]}
-      </p>
-    )
+      </p>,
+    );
   }
 
-  return content
-}
+  return content;
+};
 
 const hierarchicalColor = (
   colorHash: { [index: string]: string },
-  datapoint: Dx.Datapoint
+  datapoint: Dx.Datapoint,
 ) => {
   if (datapoint.depth === 0) {
-    return "white"
+    return "white";
   }
   if (datapoint.depth === 1) {
-    return colorHash[datapoint.key]
+    return colorHash[datapoint.key];
   }
-  let colorNode = datapoint
+  let colorNode = datapoint;
   for (let x = datapoint.depth; x > 1; x--) {
-    colorNode = colorNode.parent
+    colorNode = colorNode.parent;
   }
-  const lightenScale = interpolateLab("white", colorHash[colorNode.key])
+  const lightenScale = interpolateLab("white", colorHash[colorNode.key]);
 
-  return lightenScale(Math.max(0, datapoint.depth / 6))
-}
+  return lightenScale(Math.max(0, datapoint.depth / 6));
+};
 
 export const semioticHierarchicalChart = (
   data: Dx.DataProps["data"],
   schema: Dx.DataProps["schema"],
   options: HierarchicalOptions,
   colorHashOverride?: { key?: string },
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
   const {
     hierarchyType: baseHierarchyType = "dendrogram",
     chart,
     selectedDimensions,
     primaryKey,
-    colors
-  } = options
-  const { metric1 } = chart
+    colors,
+  } = options;
+  const { metric1 } = chart;
 
   // a sunburst is just a radial partition
   const hierarchyType =
-    baseHierarchyType === "sunburst" ? "partition" : baseHierarchyType
+    baseHierarchyType === "sunburst" ? "partition" : baseHierarchyType;
 
   if (selectedDimensions.length === 0) {
-    return {}
+    return {};
   }
 
-  const nestingParams = nest<{ [index: string]: string }>()
+  const nestingParams = nest<{ [index: string]: string }>();
 
   selectedDimensions.forEach((dim: string) => {
-    nestingParams.key((param: { [index: string]: string }) => param[dim])
-  })
+    nestingParams.key((param: { [index: string]: string }) => param[dim]);
+  });
 
-  const colorHash: any = colorHashOverride || {}
-  const sanitizedData: Array<any> = []
+  const colorHash: any = colorHashOverride || {};
+  const sanitizedData: Array<any> = [];
 
   data.forEach((datapoint: Dx.Datapoint) => {
     if (!colorDimOverride && !colorHash[datapoint[selectedDimensions[0]]]) {
       colorHash[datapoint[selectedDimensions[0]]] =
-        colors[Object.keys(colorHash).length]
+        colors[Object.keys(colorHash).length];
     }
 
     sanitizedData.push({
       ...datapoint,
       sanitizedR: datapoint.r,
-      r: undefined
-    })
-  })
+      r: undefined,
+    });
+  });
 
   const entries = nestingParams.entries(
-    sanitizedData.sort((a, b) => a[metric1] - b[metric1])
-  )
-  const rootNode = { id: "all", values: entries }
+    sanitizedData.sort((a, b) => a[metric1] - b[metric1]),
+  );
+  const rootNode = { id: "all", values: entries };
 
   const hierarchySettings = {
     edges: rootNode,
@@ -211,8 +212,8 @@ export const semioticHierarchicalChart = (
       return {
         fill: hierarchicalColor(colorHash, node),
         stroke: node.depth === 1 ? "white" : "black",
-        strokeOpacity: node.depth * 0.1 + 0.2
-      }
+        strokeOpacity: node.depth * 0.1 + 0.2,
+      };
     },
     networkType: {
       type: hierarchyType,
@@ -220,10 +221,10 @@ export const semioticHierarchicalChart = (
       hierarchySum: (node: { [index: string]: number }) => node[metric1],
       hierarchyChildren: (node: { values: Array<{}> }) => node.values,
       padding: hierarchyType === "treemap" ? 3 : 0,
-      zoom: false
+      zoom: false,
     },
     edgeRenderKey: (edge: object, index: number) => {
-      return index
+      return index;
     },
     nodeIDAccessor: (d: any, i: any) => d.id || d.key || i,
     baseMarkProps: { forceUpdate: true },
@@ -236,14 +237,14 @@ export const semioticHierarchicalChart = (
           stroke: "red",
           strokeOpacity: 0.5,
           strokeWidth: 5,
-          fill: "none"
-        }
-      }
+          fill: "none",
+        },
+      },
     ],
     svgAnnotationRules: hierarchicalAnnotation(
       hierarchyType,
       selectedDimensions,
-      metric1
+      metric1,
     ),
     htmlAnnotationRules: overrideFrameHover(hierarchyType),
     tooltipContent: (hoveredDatapoint: Dx.Datapoint) => {
@@ -253,16 +254,16 @@ export const semioticHierarchicalChart = (
             hoveredDatapoint,
             primaryKey,
             metric1,
-            selectedDimensions
+            selectedDimensions,
           )}
         </TooltipContent>
-      )
-    }
-  }
+      );
+    },
+  };
 
   return {
     frameSettings: hierarchySettings,
     colorDim: selectedDimensions[0],
-    colorHash
-  }
-}
+    colorHash,
+  };
+};

--- a/src/charts/line.tsx
+++ b/src/charts/line.tsx
@@ -18,31 +18,25 @@ interface LineOptions {
 export const semioticLineChart = (
   data: Dx.Datapoint[],
   schema: Dx.Schema,
-  options: LineOptions
+  options: LineOptions,
 ) => {
   let lineData;
 
-  const {
-    chart,
-    selectedMetrics,
-    lineType,
-    metrics,
-    primaryKey,
-    colors
-  } = options;
+  const { chart, selectedMetrics, lineType, metrics, primaryKey, colors } =
+    options;
   // const F = (a: number, b:Dx.Chart): string[]=> selectedMetrics;
   const { timeseriesSort } = chart;
 
   const timeSeriesFields = schema.fields.find(
-    field => field && field.name === timeseriesSort
+    (field) => field && field.name === timeseriesSort,
   );
 
   const sortType =
     timeseriesSort === "array-order"
       ? "integer"
       : timeSeriesFields && timeSeriesFields.type
-        ? timeSeriesFields.type
-        : null;
+      ? timeSeriesFields.type
+      : null;
 
   const formatting = (tickValue: Date | number) =>
     sortType === "datetime"
@@ -51,40 +45,40 @@ export const semioticLineChart = (
 
   const xScale = sortType === "datetime" ? scaleTime() : scaleLinear();
   lineData = metrics
-    .map(
-      (metric: Dx.Metric, index: number): Dx.LineData => {
-        const metricData =
-          timeseriesSort === "array-order"
-            ? data
-            : data.sort(
+    .map((metric: Dx.Metric, index: number): Dx.LineData => {
+      const metricData =
+        timeseriesSort === "array-order"
+          ? data
+          : data.sort(
               // Using some questionable type assertions here
               (datapointA, datapointB) =>
-                datapointA[timeseriesSort] - datapointB[timeseriesSort]
+                datapointA[timeseriesSort] - datapointB[timeseriesSort],
             );
-        return {
-          color: colors[index % colors.length],
+      return {
+        color: colors[index % colors.length],
+        label: metric.name,
+        type: metric.type,
+        coordinates: metricData.map((datapoint, datapointValue) => ({
+          value: datapoint[metric.name],
+          x:
+            timeseriesSort === "array-order"
+              ? datapointValue
+              : datapoint[timeseriesSort],
           label: metric.name,
-          type: metric.type,
-          coordinates: metricData.map((datapoint, datapointValue) => ({
-            value: datapoint[metric.name],
-            x:
-              timeseriesSort === "array-order"
-                ? datapointValue
-                : datapoint[timeseriesSort],
-            label: metric.name,
-            color: colors[index % colors.length],
-            originalData: datapoint
-          }))
-        };
-      }
-    )
+          color: colors[index % colors.length],
+          originalData: datapoint,
+        })),
+      };
+    })
     .filter(
       (metric: Dx.LineData) =>
         selectedMetrics.length === 0 ||
-        selectedMetrics.some(selectedMetric => selectedMetric === metric.label)
+        selectedMetrics.some(
+          (selectedMetric) => selectedMetric === metric.label,
+        ),
     );
 
-  const canvasRender: boolean = lineData[0].coordinates.length > 250
+  const canvasRender: boolean = lineData[0].coordinates.length > 250;
 
   const lineSettings = {
     lineType: { type: lineType, interpolator: curveMonotoneX },
@@ -93,7 +87,7 @@ export const semioticLineChart = (
     canvasLines: canvasRender,
     renderKey: (
       line: { coordinates: Dx.LineCoordinate[]; label: string; line: string },
-      index: number
+      index: number,
     ) => {
       return line.coordinates
         ? `line-${line.label}`
@@ -102,12 +96,12 @@ export const semioticLineChart = (
     lineStyle: (line: Dx.LineCoordinate) => ({
       fill: lineType === "line" ? "none" : line.color,
       stroke: line.color,
-      fillOpacity: 0.75
+      fillOpacity: 0.75,
     }),
     pointStyle: (point: Dx.LineData) => {
       return {
         fill: point.color,
-        fillOpacity: 0.75
+        fillOpacity: 0.75,
       };
     },
     axes: [
@@ -124,8 +118,8 @@ export const semioticLineChart = (
               {label}
             </text>
           );
-        }
-      }
+        },
+      },
     ],
     hoverAnnotation: true,
     xAccessor: "x",
@@ -135,7 +129,7 @@ export const semioticLineChart = (
       top: 20,
       right: 200,
       bottom: sortType === "datetime" ? 80 : 40,
-      left: 50
+      left: 50,
     },
     legend: {
       title: "Legend",
@@ -145,9 +139,9 @@ export const semioticLineChart = (
         {
           label: "",
           styleFn: (legendItem: Dx.LineData) => ({ fill: legendItem.color }),
-          items: lineData
-        }
-      ]
+          items: lineData,
+        },
+      ],
     },
     tooltipContent: (hoveredDatapoint: Dx.Datapoint) => {
       return (
@@ -173,9 +167,8 @@ export const semioticLineChart = (
           ))}
         </TooltipContent>
       );
-    }
-  }
+    },
+  };
 
-  return { frameSettings: lineSettings, colorDim: "none", colorHash: {} }
-
+  return { frameSettings: lineSettings, colorDim: "none", colorHash: {} };
 };

--- a/src/charts/network.tsx
+++ b/src/charts/network.tsx
@@ -26,71 +26,68 @@ interface NetworkOptions {
   networkType: Dx.NetworkType;
 }
 
-const fontScale = scaleLinear()
-  .domain([5, 30])
-  .range([8, 16])
-  .clamp(true);
+const fontScale = scaleLinear().domain([5, 30]).range([8, 16]).clamp(true);
 
 const edgeStyles = {
   force: (colorHash: Dx.JSONObject) => (edge: EdgeObject) => ({
     fill: colorHash[edge.source.id],
     stroke: colorHash[edge.source.id],
-    strokeOpacity: 0.25
+    strokeOpacity: 0.25,
   }),
   sankey: (colorHash: Dx.JSONObject) => (edge: EdgeObject) => ({
     fill: colorHash[edge.source.id],
     stroke: colorHash[edge.source.id],
-    strokeOpacity: 0.25
+    strokeOpacity: 0.25,
   }),
   matrix: (colorHash: Dx.JSONObject) => (edge: EdgeObject) => ({
     fill: colorHash[edge.source.id],
-    stroke: "none"
+    stroke: "none",
   }),
   arc: (colorHash: Dx.JSONObject) => (edge: EdgeObject) => ({
     fill: "none",
     stroke: colorHash[edge.source.id],
     strokeWidth: edge.weight || 1,
-    strokeOpacity: 0.75
-  })
+    strokeOpacity: 0.75,
+  }),
 };
 
 const nodeStyles = {
   force: (colorHash: Dx.JSONObject) => (node: NodeObject) => ({
     fill: colorHash[node.id],
     stroke: colorHash[node.id],
-    strokeOpacity: 0.5
+    strokeOpacity: 0.5,
   }),
   sankey: (colorHash: Dx.JSONObject) => (node: NodeObject) => ({
     fill: colorHash[node.id],
     stroke: colorHash[node.id],
-    strokeOpacity: 0.5
+    strokeOpacity: 0.5,
   }),
   matrix: (colorHash: Dx.JSONObject) => (node: NodeObject) => ({
     fill: "none",
     stroke: "#666",
-    strokeOpacity: 1
+    strokeOpacity: 1,
   }),
   arc: (colorHash: Dx.JSONObject) => (node: NodeObject) => ({
     fill: colorHash[node.id],
     stroke: colorHash[node.id],
-    strokeOpacity: 0.5
-  })
+    strokeOpacity: 0.5,
+  }),
 };
 const nodeLinkHover = [
   { type: "frame-hover" },
   {
     type: "highlight",
-    style: { stroke: "red", strokeOpacity: 0.5, strokeWidth: 5, fill: "none" }
-  }
+    style: { stroke: "red", strokeOpacity: 0.5, strokeWidth: 5, fill: "none" },
+  },
 ];
 const hoverAnnotationSettings = {
   force: nodeLinkHover,
   sankey: nodeLinkHover,
   matrix: [
     { type: "frame-hover" },
-    { type: "highlight", style: { fill: "red", fillOpacity: 0.5 } }
+    { type: "highlight", style: { fill: "red", fillOpacity: 0.5 } },
   ],
-  arc: nodeLinkHover
+  arc: nodeLinkHover,
 };
 
 const nodeLabeling: {
@@ -111,7 +108,7 @@ const nodeLabeling: {
         {d.id}
       </text>
     );
-  }
+  },
 };
 
 export const semioticNetwork = (
@@ -119,14 +116,14 @@ export const semioticNetwork = (
   schema: Dx.DataProps["schema"],
   options: NetworkOptions,
   colorHashOverride?: { key?: string },
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
   const { networkType = "force", chart, colors } = options;
   const {
     dim1: sourceDimension,
     dim2: targetDimension,
     metric1,
-    networkLabel
+    networkLabel,
   } = chart;
 
   if (
@@ -140,16 +137,16 @@ export const semioticNetwork = (
   const edgeHash: { [index: string]: EdgeObject } = {};
   const networkData: EdgeObject[] = [];
 
-  data.forEach(edge => {
+  data.forEach((edge) => {
     if (!edgeHash[`${edge[sourceDimension]}-${edge[targetDimension]}`]) {
       edgeHash[`${edge[sourceDimension]}-${edge[targetDimension]}`] = {
         source: edge[sourceDimension],
         target: edge[targetDimension],
         value: 0,
-        weight: 0
+        weight: 0,
       };
       networkData.push(
-        edgeHash[`${edge[sourceDimension]}-${edge[targetDimension]}`]
+        edgeHash[`${edge[sourceDimension]}-${edge[targetDimension]}`],
       );
     }
     edgeHash[`${edge[sourceDimension]}-${edge[targetDimension]}`].value +=
@@ -160,7 +157,7 @@ export const semioticNetwork = (
   const colorHash: any = colorHashOverride || {};
 
   if (!colorHashOverride) {
-    data.forEach(edge => {
+    data.forEach((edge) => {
       if (!colorHash[edge[sourceDimension]]) {
         colorHash[edge[sourceDimension]] =
           colors[Object.keys(colorHash).length % colors.length];
@@ -171,7 +168,7 @@ export const semioticNetwork = (
       }
     });
   }
-  networkData.forEach(edge => {
+  networkData.forEach((edge) => {
     edge.weight = Math.min(10, edge.weight);
   });
 
@@ -183,7 +180,7 @@ export const semioticNetwork = (
     nodeSizeAccessor: (node: NodeObject) => node.degree,
     networkType: {
       type: networkType,
-      iterations: 1000
+      iterations: 1000,
     },
     hoverAnnotation: hoverAnnotationSettings[networkType],
     tooltipContent: (hoveredNode: NodeObject) => {
@@ -196,8 +193,11 @@ export const semioticNetwork = (
       );
     },
     nodeLabels: networkType === "matrix" ? false : nodeLabeling[networkLabel],
-    margin: { left: 100, right: 100, top: 10, bottom: 10 }
-  }
-  return { frameSettings: networkSettings, colorDim: sourceDimension, colorHash }
-
+    margin: { left: 100, right: 100, top: 10, bottom: 10 },
+  };
+  return {
+    frameSettings: networkSettings,
+    colorDim: sourceDimension,
+    colorHash,
+  };
 };

--- a/src/charts/settings.tsx
+++ b/src/charts/settings.tsx
@@ -4,7 +4,7 @@ import {
   ResponsiveXYFrame,
   NetworkFrame,
   OrdinalFrame,
-  XYFrame
+  XYFrame,
 } from "semiotic";
 
 import ParallelCoordinatesController from "../components/ParallelCoordinatesController";
@@ -21,14 +21,14 @@ import * as Dx from "../utilities/types";
 const semioticParallelCoordinates = (
   data: Dx.Datapoint[],
   schema: Dx.Schema,
-  options: Dx.ChartOptions
+  options: Dx.ChartOptions,
 ) => {
   return {
     frameSettings: {
       data,
       schema,
-      options
-    }
+      options,
+    },
   };
 };
 
@@ -37,48 +37,48 @@ export const semioticSettings: Dx.SemioticSettings = {
     Frame: ResponsiveXYFrame,
     controls: "switch between linetype",
     chartGenerator: semioticLineChart,
-    FacetFrame: XYFrame
+    FacetFrame: XYFrame,
   },
   scatter: {
     Frame: ResponsiveXYFrame,
     controls: "switch between modes",
     chartGenerator: semioticScatterplot,
-    FacetFrame: XYFrame
+    FacetFrame: XYFrame,
   },
   hexbin: {
     Frame: ResponsiveXYFrame,
     controls: "switch between modes",
     chartGenerator: semioticHexbin,
-    FacetFrame: XYFrame
+    FacetFrame: XYFrame,
   },
   bar: {
     Frame: ResponsiveOrdinalFrame,
     controls: "switch between modes",
     chartGenerator: semioticBarChart,
-    FacetFrame: OrdinalFrame
+    FacetFrame: OrdinalFrame,
   },
   summary: {
     Frame: ResponsiveOrdinalFrame,
     controls: "switch between modes",
     chartGenerator: semioticSummaryChart,
-    FacetFrame: OrdinalFrame
+    FacetFrame: OrdinalFrame,
   },
   network: {
     Frame: ResponsiveNetworkFrame,
     controls: "switch between modes",
     chartGenerator: semioticNetwork,
-    FacetFrame: NetworkFrame
+    FacetFrame: NetworkFrame,
   },
   hierarchy: {
     Frame: ResponsiveNetworkFrame,
     controls: "switch between modes",
     chartGenerator: semioticHierarchicalChart,
-    FacetFrame: NetworkFrame
+    FacetFrame: NetworkFrame,
   },
   parallel: {
     Frame: ParallelCoordinatesController,
     controls: "switch between modes",
     chartGenerator: semioticParallelCoordinates,
-    FacetFrame: ParallelCoordinatesController
-  }
+    FacetFrame: ParallelCoordinatesController,
+  },
 };

--- a/src/charts/shared.tsx
+++ b/src/charts/shared.tsx
@@ -2,7 +2,7 @@ import * as Dx from "../utilities/types";
 
 function stringOrFnAccessor(
   datapoint: Dx.Datapoint,
-  accessor: string | Function
+  accessor: string | Function,
 ) {
   return typeof accessor === "function"
     ? accessor(datapoint)
@@ -19,11 +19,11 @@ export const sortByOrdinalRange = (
   oAccessor: string | ((datapoint: Dx.Datapoint) => string),
   rAccessor: string | (() => void),
   secondarySort: string,
-  data: Dx.DataProps["data"]
+  data: Dx.DataProps["data"],
 ): any[] => {
   const subsortData: { [index: string]: SubsortObject } = {};
   let subsortArrays: SubsortObject[] = [];
-  data.forEach(datapoint => {
+  data.forEach((datapoint) => {
     const ordinalValue = stringOrFnAccessor(datapoint, oAccessor);
     if (!subsortData[ordinalValue]) {
       subsortData[ordinalValue] = { array: [], value: 0, label: ordinalValue };
@@ -48,11 +48,11 @@ export const sortByOrdinalRange = (
   });
 
   if (secondarySort !== "none") {
-    subsortArrays.forEach(ordinalData => {
+    subsortArrays.forEach((ordinalData) => {
       ordinalData.array = ordinalData.array.sort(
         (ordinalAData, ordinalBData) =>
           stringOrFnAccessor(ordinalBData, secondarySort) -
-          stringOrFnAccessor(ordinalAData, secondarySort)
+          stringOrFnAccessor(ordinalAData, secondarySort),
       );
     });
   }
@@ -60,8 +60,8 @@ export const sortByOrdinalRange = (
   return subsortArrays.reduce(
     (combinedArray: Dx.Datapoint[], ordinalData) => [
       ...combinedArray,
-      ...ordinalData.array
+      ...ordinalData.array,
     ],
-    []
+    [],
   );
 };

--- a/src/charts/summary.tsx
+++ b/src/charts/summary.tsx
@@ -1,64 +1,55 @@
-import { scaleLinear } from "d3-scale"
-import * as React from "react"
+import { scaleLinear } from "d3-scale";
+import * as React from "react";
 
-import HTMLLegend from "../components/HTMLLegend"
-import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content"
-import * as Dx from "../utilities/types"
-import { numeralFormatting } from "../utilities/utilities"
+import HTMLLegend from "../components/HTMLLegend";
+import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content";
+import * as Dx from "../utilities/types";
+import { numeralFormatting } from "../utilities/utilities";
 
 interface SummaryOptions {
-  chart: Dx.Chart
-  colors: Dx.ChartOptions["colors"]
-  primaryKey: string[]
-  setColor: Dx.ChartOptions["setColor"]
-  summaryType: Dx.SummaryType
-  showLegend: boolean
-  dimensions: Dx.Dimension[]
+  chart: Dx.Chart;
+  colors: Dx.ChartOptions["colors"];
+  primaryKey: string[];
+  setColor: Dx.ChartOptions["setColor"];
+  summaryType: Dx.SummaryType;
+  showLegend: boolean;
+  dimensions: Dx.Dimension[];
 }
 
-const fontScale = scaleLinear()
-  .domain([8, 25])
-  .range([14, 8])
-  .clamp(true)
+const fontScale = scaleLinear().domain([8, 25]).range([14, 8]).clamp(true);
 
 export const semioticSummaryChart = (
   data: Dx.DataProps["data"],
   schema: Dx.DataProps["schema"],
   options: SummaryOptions,
   colorHashOverride?: any,
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
-  const additionalSettings: { afterElements?: JSX.Element } = {}
-  const colorHash = colorHashOverride || {}
+  const additionalSettings: { afterElements?: JSX.Element } = {};
+  const colorHash = colorHashOverride || {};
 
-  const {
-    chart,
-    summaryType,
-    primaryKey,
-    colors,
-    setColor,
-    showLegend
-  } = options
+  const { chart, summaryType, primaryKey, colors, setColor, showLegend } =
+    options;
 
-  const { dim1, metric1 } = chart
+  const { dim1, metric1 } = chart;
 
-  const oAccessor = dim1
+  const oAccessor = dim1;
 
-  const rAccessor = metric1
+  const rAccessor = metric1;
 
   const uniqueValues = data.reduce(
     (uniqueArray: string[], datapoint) =>
       (!uniqueArray.find(
-        (dimValue: string) => dimValue === datapoint[dim1].toString()
+        (dimValue: string) => dimValue === datapoint[dim1].toString(),
       ) && [...uniqueArray, datapoint[dim1].toString()]) ||
       uniqueArray,
-    []
-  )
+    [],
+  );
 
   if (!colorHashOverride && dim1 && dim1 !== "none") {
     uniqueValues.sort().forEach((dimValue, index) => {
-      colorHash[dimValue] = colors[index % colors.length]
-    })
+      colorHash[dimValue] = colors[index % colors.length];
+    });
     if (showLegend) {
       additionalSettings.afterElements = (
         <HTMLLegend
@@ -67,7 +58,7 @@ export const semioticSummaryChart = (
           setColor={setColor}
           colors={colors}
         />
-      )
+      );
     }
   }
 
@@ -81,11 +72,12 @@ export const semioticSummaryChart = (
     summaryStyle: (summaryDatapoint: Dx.Datapoint) => ({
       fill: colorHash[summaryDatapoint[colorDimOverride || dim1]] || colors[0],
       fillOpacity: 0.8,
-      stroke: colorHash[summaryDatapoint[colorDimOverride || dim1]] || colors[0]
+      stroke:
+        colorHash[summaryDatapoint[colorDimOverride || dim1]] || colors[0],
     }),
     style: (pieceDatapoint: Dx.Datapoint) => ({
       fill: colorHash[pieceDatapoint[colorDimOverride || dim1]] || colors[0],
-      stroke: "white"
+      stroke: "white",
     }),
     oPadding: 5,
     oLabel:
@@ -94,8 +86,9 @@ export const semioticSummaryChart = (
         : (columnName: string) => (
             <text
               textAnchor="end"
-              fontSize={`${(columnName && fontScale(columnName.length)) ||
-                12}px`}
+              fontSize={`${
+                (columnName && fontScale(columnName.length)) || 12
+              }px`}
             >
               {columnName}
             </text>
@@ -105,21 +98,21 @@ export const semioticSummaryChart = (
       {
         orient: "bottom",
         label: rAccessor,
-        tickFormat: numeralFormatting
-      }
+        tickFormat: numeralFormatting,
+      },
     ],
     baseMarkProps: { forceUpdate: true },
     pieceHoverAnnotation: summaryType === "violin",
     tooltipContent: (hoveredDatapoint: Dx.Datapoint) => {
-      const dimensions = options.dimensions.filter(dim => dim.name !== dim1)
-      const furtherDims = dimensions.map(dim => (
+      const dimensions = options.dimensions.filter((dim) => dim.name !== dim1);
+      const furtherDims = dimensions.map((dim) => (
         <p>
           {dim.name}: {safeDisplayValue(hoveredDatapoint[dim.name])}
         </p>
-      ))
+      ));
       return (
         <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
-          <h3>{primaryKey.map(pkey => hoveredDatapoint[pkey]).join(", ")}</h3>
+          <h3>{primaryKey.map((pkey) => hoveredDatapoint[pkey]).join(", ")}</h3>
           <p>
             {dim1}: {safeDisplayValue(hoveredDatapoint[dim1])}
           </p>
@@ -128,10 +121,10 @@ export const semioticSummaryChart = (
             {rAccessor}: {safeDisplayValue(hoveredDatapoint[rAccessor])}
           </p>
         </TooltipContent>
-      )
+      );
     },
-    ...additionalSettings
-  }
+    ...additionalSettings,
+  };
 
-  return { frameSettings: summarySettings, colorDim: dim1, colorHash }
-}
+  return { frameSettings: summarySettings, colorDim: dim1, colorHash };
+};

--- a/src/charts/xyplot.tsx
+++ b/src/charts/xyplot.tsx
@@ -38,7 +38,7 @@ interface XYPlotOptions {
 
 const binHash = {
   heatmap: heatmapping,
-  hexbin: hexbinning
+  hexbin: hexbinning,
 };
 
 const steps = ["none", "#FBEEEC", "#f3c8c2", "#e39787", "#ce6751", "#b3331d"];
@@ -49,21 +49,21 @@ const thresholds = scaleThreshold<number, string>()
 function combineTopAnnotations(
   topQ: Dx.Datapoint[],
   topSecondQ: Dx.Datapoint[],
-  dim2: string
+  dim2: string,
 ): any[] {
   const combinedAnnotations: Dx.JSONObject[] = [];
   const combinedHash: {
     [index: string]: { [index: string]: any; coordinates: Dx.Datapoint[] };
   } = {};
-  [...topQ, ...topSecondQ].forEach(topDatapoint => {
+  [...topQ, ...topSecondQ].forEach((topDatapoint) => {
     const hashD = combinedHash[topDatapoint[dim2]];
 
     if (hashD) {
       const newCoordinates = (hashD.coordinates && [
         ...hashD.coordinates,
-        topDatapoint
+        topDatapoint,
       ]) || [topDatapoint, hashD];
-      Object.keys(combinedHash[topDatapoint[dim2]]).forEach(key => {
+      Object.keys(combinedHash[topDatapoint[dim2]]).forEach((key) => {
         delete combinedHash[topDatapoint[dim2]][key];
       });
       combinedHash[topDatapoint[dim2]].id = topDatapoint[dim2];
@@ -76,7 +76,7 @@ function combineTopAnnotations(
         label: topDatapoint[dim2],
         id: topDatapoint[dim2],
         coordinates: [],
-        ...topDatapoint
+        ...topDatapoint,
       };
       combinedAnnotations.push(combinedHash[topDatapoint[dim2]]);
     }
@@ -89,9 +89,16 @@ export const semioticHexbin = (
   schema: Dx.DataProps["schema"],
   options: XYPlotOptions,
   colorHashOverride?: { key?: string },
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
-  return semioticXYPlot(data, schema, options, options.areaType, colorHashOverride, colorDimOverride);
+  return semioticXYPlot(
+    data,
+    schema,
+    options,
+    options.areaType,
+    colorHashOverride,
+    colorDimOverride,
+  );
 };
 
 export const semioticScatterplot = (
@@ -99,9 +106,17 @@ export const semioticScatterplot = (
   schema: Dx.DataProps["schema"],
   options: XYPlotOptions,
   colorHashOverride?: { key?: string },
-  colorDimOverride?: string) => {
-  return semioticXYPlot(data, schema, options, "scatterplot", colorHashOverride, colorDimOverride)
-}
+  colorDimOverride?: string,
+) => {
+  return semioticXYPlot(
+    data,
+    schema,
+    options,
+    "scatterplot",
+    colorHashOverride,
+    colorDimOverride,
+  );
+};
 
 export const semioticXYPlot = (
   data: Dx.DataProps["data"],
@@ -109,7 +124,7 @@ export const semioticXYPlot = (
   options: XYPlotOptions,
   type: string = "scatterplot",
   colorHashOverride?: { key?: string },
-  colorDimOverride?: string
+  colorDimOverride?: string,
 ) => {
   const height = options.height - 150 || 500;
 
@@ -120,7 +135,7 @@ export const semioticXYPlot = (
     setColor,
     dimensions,
     trendLine,
-    marginalGraphics
+    marginalGraphics,
   } = options;
 
   const { dim1, dim2, dim3, metric1, metric2, metric3 } = chart;
@@ -129,14 +144,14 @@ export const semioticXYPlot = (
     (datapoint: Dx.Datapoint) =>
       datapoint[metric1] &&
       datapoint[metric2] &&
-      (!metric3 || metric3 === "none" || datapoint[metric3])
+      (!metric3 || metric3 === "none" || datapoint[metric3]),
   );
 
   const pointTooltip = (hoveredDatapoint: Dx.Datapoint) => {
     return (
       <TooltipContent x={hoveredDatapoint.x} y={hoveredDatapoint.y}>
-        <h3>{primaryKey.map(pkey => hoveredDatapoint[pkey]).join(", ")}</h3>
-        {dimensions.map(dim => (
+        <h3>{primaryKey.map((pkey) => hoveredDatapoint[pkey]).join(", ")}</h3>
+        {dimensions.map((dim) => (
           <p key={`tooltip-dim-${dim.name}`}>
             {dim.name}:{" "}
             {(hoveredDatapoint[dim.name].toString &&
@@ -174,10 +189,10 @@ export const semioticXYPlot = (
           (binnedDatapoint: { [index: string]: any }, index: number) => {
             const id = dimensions
               .map(
-                dim =>
+                (dim) =>
                   (binnedDatapoint[dim.name].toString &&
                     binnedDatapoint[dim.name].toString()) ||
-                  binnedDatapoint[dim.name]
+                  binnedDatapoint[dim.name],
               )
               .join(",");
             return (
@@ -185,7 +200,7 @@ export const semioticXYPlot = (
                 {id}, {binnedDatapoint[metric1]}, {binnedDatapoint[metric2]}
               </TooltipP>
             );
-          }
+          },
         )}
       </TooltipContent>
     );
@@ -200,14 +215,14 @@ export const semioticXYPlot = (
   if (dim2 && dim2 !== "none") {
     const topQ = [...filteredData]
       .sort(
-        (datapointA, datapointB) => datapointB[metric1] - datapointA[metric1]
+        (datapointA, datapointB) => datapointB[metric1] - datapointA[metric1],
       )
       .filter((d, index) => index < 3);
     const topSecondQ = [...filteredData]
       .sort(
-        (datapointA, datapointB) => datapointB[metric2] - datapointA[metric2]
+        (datapointA, datapointB) => datapointB[metric2] - datapointA[metric2],
       )
-      .filter(datapoint => topQ.indexOf(datapoint) === -1)
+      .filter((datapoint) => topQ.indexOf(datapoint) === -1)
       .filter((d, index) => index < 3);
 
     annotations = combineTopAnnotations(topQ, topSecondQ, dim2);
@@ -218,21 +233,19 @@ export const semioticXYPlot = (
 
   if (metric3 && metric3 !== "none") {
     const dataMin = Math.min(
-      ...filteredData.map(datapoint => datapoint[metric3])
+      ...filteredData.map((datapoint) => datapoint[metric3]),
     );
     const dataMax = Math.max(
-      ...filteredData.map(datapoint => datapoint[metric3])
+      ...filteredData.map((datapoint) => datapoint[metric3]),
     );
-    sizeScale = scaleLinear()
-      .domain([dataMin, dataMax])
-      .range([2, 20]);
+    sizeScale = scaleLinear().domain([dataMin, dataMax]).range([2, 20]);
   }
 
   const sortedData = sortByOrdinalRange(
     metric1,
     (metric3 !== "none" && metric3) || metric2,
     "none",
-    data
+    data,
   );
 
   if (
@@ -243,15 +256,16 @@ export const semioticXYPlot = (
     const uniqueValues = sortedData.reduce(
       (uniqueArray, datapoint) =>
         (!uniqueArray.find(
-          (uniqueDim: string) => uniqueDim === datapoint[dim1].toString()
+          (uniqueDim: string) => uniqueDim === datapoint[dim1].toString(),
         ) && [...uniqueArray, datapoint[dim1].toString()]) ||
         uniqueArray,
-      []
+      [],
     );
 
     if (!colorHashOverride) {
       uniqueValues.sort().forEach((dimValue: string, index: number) => {
-        colorHash[dimValue] = index > 18 ? "grey" : colors[index % colors.length];
+        colorHash[dimValue] =
+          index > 18 ? "grey" : colors[index % colors.length];
       });
     }
 
@@ -277,28 +291,28 @@ export const semioticXYPlot = (
       const calculatedAreas = binHash[type]({
         summaryType: { type, bins: 10 },
         data: {
-          coordinates: filteredData.map(datapoint => ({
+          coordinates: filteredData.map((datapoint) => ({
             ...datapoint,
             x: datapoint[metric1],
-            y: datapoint[metric2]
-          }))
+            y: datapoint[metric2],
+          })),
         },
-        size: [height, height]
+        size: [height, height],
       });
 
       areas = calculatedAreas;
 
       const thresholdSteps = [0.2, 0.4, 0.6, 0.8, 1]
-        .map(thresholdValue =>
-          Math.floor(calculatedAreas.binMax * thresholdValue)
+        .map((thresholdValue) =>
+          Math.floor(calculatedAreas.binMax * thresholdValue),
         )
         .reduce(
           (thresholdArray: number[], thresholdValue: number) =>
             thresholdValue === 0 ||
-              thresholdArray.indexOf(thresholdValue) !== -1
+            thresholdArray.indexOf(thresholdValue) !== -1
               ? thresholdArray
               : [...thresholdArray, thresholdValue],
-          []
+          [],
         );
 
       const withZeroThresholdSteps = [0, ...thresholdSteps];
@@ -317,7 +331,7 @@ export const semioticXYPlot = (
         "#f3c8c2",
         "#e39787",
         "#ce6751",
-        "#b3331d"
+        "#b3331d",
       ];
       const hexHash: { [index: string]: string } = {};
 
@@ -329,7 +343,9 @@ export const semioticXYPlot = (
         .domain([0.01, ...thresholdSteps])
         .range([
           "none",
-          ...thresholdColors.filter((d, index) => index < thresholdSteps.length)
+          ...thresholdColors.filter(
+            (d, index) => index < thresholdSteps.length,
+          ),
         ]);
 
       additionalSettings.afterElements = (
@@ -351,12 +367,12 @@ export const semioticXYPlot = (
       };
     } = {};
     areas = [];
-    filteredData.forEach(datapoint => {
+    filteredData.forEach((datapoint) => {
       if (!multiclassHash[datapoint[dim1]]) {
         multiclassHash[datapoint[dim1]] = {
           label: datapoint[dim1],
           color: colorHash[datapoint[dim1]],
-          coordinates: []
+          coordinates: [],
         };
         areas.push(multiclassHash[datapoint[dim1]]);
       }
@@ -377,8 +393,8 @@ export const semioticXYPlot = (
         tickFormat: () => "",
         marginalSummaryType: {
           type: marginalGraphics,
-          showPoints: !renderInCanvas
-        }
+          showPoints: !renderInCanvas,
+        },
       },
       {
         orient: "top",
@@ -386,9 +402,9 @@ export const semioticXYPlot = (
         tickFormat: () => "",
         marginalSummaryType: {
           type: marginalGraphics,
-          showPoints: !renderInCanvas
-        }
-      }
+          showPoints: !renderInCanvas,
+        },
+      },
     ];
   }
 
@@ -399,7 +415,7 @@ export const semioticXYPlot = (
     calculatedSummaryType = {
       type,
       bins: 10,
-      thresholds: dim3 === "none" ? 6 : 3
+      thresholds: dim3 === "none" ? 6 : 3,
     };
   }
 
@@ -413,7 +429,7 @@ export const semioticXYPlot = (
         label: metric2,
         tickFormat: numeralFormatting,
         baseline: type === "scatterplot",
-        tickSize: type === "heatmap" ? 0 : undefined
+        tickSize: type === "heatmap" ? 0 : undefined,
       },
       {
         orient: "bottom",
@@ -422,9 +438,9 @@ export const semioticXYPlot = (
         tickFormat: numeralFormatting,
         footer: type === "heatmap",
         baseline: type === "scatterplot",
-        tickSize: type === "heatmap" ? 0 : undefined
+        tickSize: type === "heatmap" ? 0 : undefined,
       },
-      ...marginalGraphicsAxes
+      ...marginalGraphicsAxes,
     ],
     points: (type === "scatterplot" || type === "contour") && data,
     canvasPoints: renderInCanvas,
@@ -443,9 +459,9 @@ export const semioticXYPlot = (
           type !== "contour"
             ? undefined
             : dim3 === "none"
-              ? "#BBB"
-              : areaDatapoint.parentSummary.color,
-        strokeWidth: type === "contour" ? 2 : 1
+            ? "#BBB"
+            : areaDatapoint.parentSummary.color,
+        strokeWidth: type === "contour" ? 2 : 1,
       };
     },
     pointStyle: (datapoint: Dx.Datapoint) => {
@@ -453,14 +469,18 @@ export const semioticXYPlot = (
         r: renderInCanvas
           ? 2
           : type === "contour"
-            ? 3
-            : `${sizeScale(datapoint[metric3])}px`,
+          ? 3
+          : `${sizeScale(datapoint[metric3])}px`,
         fill: colorHash[datapoint[colorDimOverride || dim1]] || "black",
         fillOpacity: 0.75,
-        stroke: renderInCanvas ? "none" : type === "contour" ? "white" : "black",
+        stroke: renderInCanvas
+          ? "none"
+          : type === "contour"
+          ? "white"
+          : "black",
         strokeWidth: type === "contour" ? 0.5 : 1,
-        strokeOpacity: 0.9
-      }
+        strokeOpacity: 0.9,
+      };
     },
     hoverAnnotation: true,
     responsiveWidth: false,
@@ -468,18 +488,17 @@ export const semioticXYPlot = (
     margin: { left: 75, bottom: 75, right: 30, top: 30 },
     annotations: (type === "scatterplot" && annotations) || undefined,
     annotationSettings: {
-      layout: { type: "marginalia", orient: "right", marginOffset: 30 }
+      layout: { type: "marginalia", orient: "right", marginOffset: 30 },
     },
     tooltipContent:
       ((type === "hexbin" || type === "heatmap") && areaTooltip) ||
       pointTooltip,
-    ...additionalSettings
+    ...additionalSettings,
   };
 
   if (type !== "scatterplot") {
     xyPlotSettings.summaries = areas;
   }
 
-  return { frameSettings: xyPlotSettings, colorDim: dim1, colorHash }
-
+  return { frameSettings: xyPlotSettings, colorDim: dim1, colorHash };
 };

--- a/src/components/DataExplorer.tsx
+++ b/src/components/DataExplorer.tsx
@@ -12,114 +12,114 @@ import { Toolbar } from "./Toolbar";
 import styled from "styled-components";
 import * as Dx from "../utilities/types";
 import {
-    AreaType,
-    Chart,
-    HierarchyType,
-    LineType,
-    NetworkType,
-    PieceType,
-    SummaryType,
-    View,
-    SemioticSettings
+  AreaType,
+  Chart,
+  HierarchyType,
+  LineType,
+  NetworkType,
+  PieceType,
+  SummaryType,
+  View,
+  SemioticSettings,
 } from "../utilities/types";
 
-import { FacetController } from "semiotic"
+import { FacetController } from "semiotic";
 
-import { extent } from "d3-array"
+import { extent } from "d3-array";
 
 const mediaType: Props["mediaType"] = "application/vnd.dataresource+json";
 
 export interface Props {
-    data: Dx.DataProps;
-    metadata: Dx.Metadata;
-    initialView: Dx.View;
-    models?: {};
-    expanded?: boolean;
-    theme?: string;
-    height?: number;
-    mediaType: "application/vnd.dataresource+json";
-    onMetadataChange?: (
-        { dx }: { dx: Dx.dxMetaProps },
-        mediaType: Props["mediaType"]
-    ) => void;
-    overrideSettings?: object;
-    OverrideVizControls?: React.ComponentType;
-    OverrideLegend?: React.ComponentType;
-    additionalViews?: SemioticSettings;
-    filterData?: Function;
-    children?: React.ReactNode
+  data: Dx.DataProps;
+  metadata: Dx.Metadata;
+  initialView: Dx.View;
+  models?: {};
+  expanded?: boolean;
+  theme?: string;
+  height?: number;
+  mediaType: "application/vnd.dataresource+json";
+  onMetadataChange?: (
+    { dx }: { dx: Dx.dxMetaProps },
+    mediaType: Props["mediaType"],
+  ) => void;
+  overrideSettings?: object;
+  OverrideVizControls?: React.ComponentType;
+  OverrideLegend?: React.ComponentType;
+  additionalViews?: SemioticSettings;
+  filterData?: Function;
+  children?: React.ReactNode;
 }
 
 interface State {
-    largeDataset: boolean;
-    view: View;
-    colors: string[];
-    metrics: Dx.Field[];
-    dimensions: Dx.Dimension[];
-    selectedMetrics: string[];
-    selectedDimensions: string[];
-    networkType: NetworkType;
-    hierarchyType: HierarchyType;
-    pieceType: PieceType;
-    summaryType: SummaryType;
-    lineType: LineType;
-    areaType: AreaType;
-    chart: Chart;
-    displayChart: DisplayChart;
-    primaryKey: string[];
-    data: Dx.Datapoint[];
-    trendLine: Dx.TrendLineType;
-    marginalGraphics: Dx.SummaryType;
-    barGrouping: Dx.BarGroupingType;
-    editable: boolean;
-    showLegend: boolean;
-    facetCharts?: Chart[];
-    facets?: Dx.facetProps[];
-    schema: Dx.Schema;
-    overrideSettings?: object;
-    filteredData?: Dx.Datapoint[];
-    props: Props
+  largeDataset: boolean;
+  view: View;
+  colors: string[];
+  metrics: Dx.Field[];
+  dimensions: Dx.Dimension[];
+  selectedMetrics: string[];
+  selectedDimensions: string[];
+  networkType: NetworkType;
+  hierarchyType: HierarchyType;
+  pieceType: PieceType;
+  summaryType: SummaryType;
+  lineType: LineType;
+  areaType: AreaType;
+  chart: Chart;
+  displayChart: DisplayChart;
+  primaryKey: string[];
+  data: Dx.Datapoint[];
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: Dx.SummaryType;
+  barGrouping: Dx.BarGroupingType;
+  editable: boolean;
+  showLegend: boolean;
+  facetCharts?: Chart[];
+  facets?: Dx.facetProps[];
+  schema: Dx.Schema;
+  overrideSettings?: object;
+  filteredData?: Dx.Datapoint[];
+  props: Props;
 }
 
 const generateChartKey = ({
-    view,
-    lineType,
-    areaType,
-    selectedDimensions,
-    selectedMetrics,
-    pieceType,
-    summaryType,
-    networkType,
-    hierarchyType,
-    trendLine,
-    marginalGraphics,
-    barGrouping,
-    chart
+  view,
+  lineType,
+  areaType,
+  selectedDimensions,
+  selectedMetrics,
+  pieceType,
+  summaryType,
+  networkType,
+  hierarchyType,
+  trendLine,
+  marginalGraphics,
+  barGrouping,
+  chart,
 }: {
-    view: View;
-    lineType: LineType;
-    areaType: AreaType;
-    selectedDimensions: string[];
-    selectedMetrics: string[];
-    pieceType: PieceType;
-    summaryType: SummaryType;
-    networkType: NetworkType;
-    hierarchyType: HierarchyType;
-    trendLine: Dx.TrendLineType;
-    marginalGraphics: SummaryType;
-    barGrouping: Dx.BarGroupingType;
-    chart: Chart;
+  view: View;
+  lineType: LineType;
+  areaType: AreaType;
+  selectedDimensions: string[];
+  selectedMetrics: string[];
+  pieceType: PieceType;
+  summaryType: SummaryType;
+  networkType: NetworkType;
+  hierarchyType: HierarchyType;
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: SummaryType;
+  barGrouping: Dx.BarGroupingType;
+  chart: Chart;
 }) =>
-    `${view}-${lineType}-${areaType}-${selectedDimensions.join(
-        ","
-    )}-${selectedMetrics.join(
-        ","
-    )}-${pieceType}-${summaryType}-${networkType}-${hierarchyType}-${trendLine}-${marginalGraphics}-${barGrouping}-${JSON.stringify(
-        chart
-    )}`;
+  `${view}-${lineType}-${areaType}-${selectedDimensions.join(
+    ",",
+  )}-${selectedMetrics.join(
+    ",",
+  )}-${pieceType}-${summaryType}-${networkType}-${hierarchyType}-${trendLine}-${marginalGraphics}-${barGrouping}-${JSON.stringify(
+    chart,
+  )}`;
 
 interface DisplayChart {
-    [chartKey: string]: React.ReactNode;
+  [chartKey: string]: React.ReactNode;
 }
 /*
   contour is an option for scatterplot
@@ -143,20 +143,20 @@ const MetadataWarningContent = styled.div`
 `;
 
 const MetadataWarning = ({ metadata }: { metadata: Dx.Metadata }) => {
-    const warning =
-        metadata && metadata.sampled ? (
-            <span>
-                <b>NOTE:</b> This data is sampled
+  const warning =
+    metadata && metadata.sampled ? (
+      <span>
+        <b>NOTE:</b> This data is sampled
       </span>
-        ) : null;
+    ) : null;
 
-    return (
-        <MetadataWarningWrapper>
-            {warning ? (
-                <MetadataWarningContent>{warning}</MetadataWarningContent>
-            ) : null}
-        </MetadataWarningWrapper>
-    );
+  return (
+    <MetadataWarningWrapper>
+      {warning ? (
+        <MetadataWarningContent>{warning}</MetadataWarningContent>
+      ) : null}
+    </MetadataWarningWrapper>
+  );
 };
 
 const FlexWrapper = styled.div`
@@ -175,7 +175,6 @@ const FacetWrapper = styled.div`
     margin: 5px;
   }
 `;
-
 
 const SemioticWrapper = styled.div`
   width: 100%;
@@ -231,238 +230,401 @@ const SemioticWrapper = styled.div`
   }
 `;
 
-const processInitialData = (props: Props, existingView?: View, existingDX?: Dx.dxMetaProps, filteredData?: Dx.Datapoint[]) => {
+const processInitialData = (
+  props: Props,
+  existingView?: View,
+  existingDX?: Dx.dxMetaProps,
+  filteredData?: Dx.Datapoint[],
+) => {
+  const { metadata, initialView, overrideSettings } = props;
 
-    const { metadata, initialView, overrideSettings } = props;
+  // Handle case of metadata being empty yet dx not set
+  const dx = existingDX || metadata.dx || { chart: {}, facets: undefined };
+  const { chart = {}, facets, ...nonChartDXSettings } = dx;
 
-    // Handle case of metadata being empty yet dx not set
-    const dx = existingDX || metadata.dx || { chart: {}, facets: undefined };
-    const { chart = {}, facets, ...nonChartDXSettings } = dx;
+  let { fields = [], primaryKey = [] } = props.data.schema;
+  // Provide a default primaryKey if none provided
+  if (primaryKey.length === 0) {
+    primaryKey = [Dx.defaultPrimaryKey];
+    fields = [...fields, { name: Dx.defaultPrimaryKey, type: "integer" }];
+  }
 
-    let { fields = [], primaryKey = [] } = props.data.schema;
-    // Provide a default primaryKey if none provided
-    if (primaryKey.length === 0) {
-        primaryKey = [Dx.defaultPrimaryKey];
-        fields = [...fields, { name: Dx.defaultPrimaryKey, type: "integer" }];
-    }
+  const dimensions = fields
+    .filter(
+      (field) =>
+        field.type === "string" ||
+        field.type === "boolean" ||
+        field.type === "datetime",
+    )
+    .map((field) => ({
+      cardinality: 0,
+      cardinalValues: [],
+      unfilteredCardinality: 0,
+      unfilteredCardinalValues: [],
+      ...field,
+    })) as Dx.Dimension[];
 
-    const dimensions = fields
-        .filter(
-            field =>
-                field.type === "string" ||
-                field.type === "boolean" ||
-                field.type === "datetime"
-        )
-        .map(field => ({ cardinality: 0, cardinalValues: [], unfilteredCardinality: 0, unfilteredCardinalValues: [], ...field })) as Dx.Dimension[];
+  // Should datetime data types be transformed into js dates before getting to this resource?
 
-    // Should datetime data types be transformed into js dates before getting to this resource?
+  const baseData = filteredData || props.data.data;
 
-    const baseData = filteredData || props.data.data
+  const data = baseData.map((datapoint, datapointIndex) => {
+    const mappedDatapoint: Dx.Datapoint = {
+      ...datapoint,
+    };
+    fields.forEach((field) => {
+      if (field.name === Dx.defaultPrimaryKey) {
+        mappedDatapoint[Dx.defaultPrimaryKey] = datapointIndex;
+      }
+      if (field.type === "datetime") {
+        mappedDatapoint[field.name] = new Date(mappedDatapoint[field.name]);
+      }
+    });
+    return mappedDatapoint;
+  });
 
-    const data = baseData.map((datapoint, datapointIndex) => {
-        const mappedDatapoint: Dx.Datapoint = {
-            ...datapoint
-        };
-        fields.forEach(field => {
-            if (field.name === Dx.defaultPrimaryKey) {
-                mappedDatapoint[Dx.defaultPrimaryKey] = datapointIndex;
-            }
-            if (field.type === "datetime") {
-                mappedDatapoint[field.name] = new Date(mappedDatapoint[field.name]);
-            }
-        });
-        return mappedDatapoint;
+  let largeDataset = true;
+  let selectedDimensions: string[] = [];
+
+  const metrics = fields
+    .filter(
+      (field) =>
+        field.type === "integer" ||
+        field.type === "number" ||
+        field.type === "datetime",
+    )
+    .filter((field) => !primaryKey.find((pkey) => pkey === field.name))
+    .map((d) => ({ ...d })) as Dx.Metric[];
+
+  if (data.length < 5000) {
+    largeDataset = false;
+  }
+
+  if (data.length < 100000) {
+    metrics.forEach((m) => {
+      if (!m.extent) {
+        m.extent = extent(data.map((d) => d[m.name]));
+      }
+      if (!m.unfilteredExtent) {
+        if (m.type === "datetime") {
+          m.unfilteredExtent = filteredData
+            ? extent(props.data.data.map((d) => new Date(d[m.name])))
+            : m.extent;
+        } else {
+          m.unfilteredExtent = filteredData
+            ? extent(props.data.data.map((d) => d[m.name]))
+            : m.extent;
+        }
+      }
     });
 
-
-    let largeDataset = true;
-    let selectedDimensions: string[] = [];
-
-
-    const metrics = fields
-        .filter(
-            field =>
-                field.type === "integer" ||
-                field.type === "number" ||
-                field.type === "datetime"
-        )
-        .filter(
-            field => !primaryKey.find(pkey => pkey === field.name)
-        ).map(d => ({ ...d })) as Dx.Metric[];
-
-    if (data.length < 5000) {
-        largeDataset = false
-    }
-
-    if (data.length < 100000) {
-        metrics.forEach(m => {
-            if (!m.extent) {
-                m.extent = extent(data.map(d => d[m.name]))
-            }
-            if (!m.unfilteredExtent) {
-                if (m.type === "datetime") {
-                    m.unfilteredExtent = filteredData ? extent(props.data.data.map(d => new Date(d[m.name]))) : m.extent
-                } else {
-                    m.unfilteredExtent = filteredData ? extent(props.data.data.map(d => d[m.name])) : m.extent
-                }
-            }
-        })
-
-        dimensions.forEach(dim => {
-            if (dim.cardinality === 0) {
-                const cardinalityHash: { [key: string]: { [key: string]: true } } = {};
-                cardinalityHash[dim.name] = {};
-                data.forEach(datapoint => {
-                    const dimValue = datapoint[dim.name];
-                    cardinalityHash[dim.name][dimValue] = true;
-                });
-
-                const dimKeys = Object.keys(cardinalityHash[dim.name])
-
-                dim.cardinality = dimKeys.length;
-                dim.cardinalValues = dimKeys
-            }
-            if (dim.unfilteredCardinality === 0) {
-                if (!filteredData) {
-                    dim.unfilteredCardinality = dim.cardinality
-                    dim.unfilteredCardinalValues = dim.cardinalValues
-                }
-                const cardinalityHash: { [key: string]: { [key: string]: true } } = {};
-                cardinalityHash[dim.name] = {};
-                props.data.data.forEach(datapoint => {
-                    const dimValue = datapoint[dim.name];
-                    cardinalityHash[dim.name][dimValue] = true;
-                });
-
-                const dimKeys = Object.keys(cardinalityHash[dim.name])
-
-                dim.unfilteredCardinality = dimKeys.length;
-                dim.unfilteredCardinalValues = dimKeys
-            }
+    dimensions.forEach((dim) => {
+      if (dim.cardinality === 0) {
+        const cardinalityHash: { [key: string]: { [key: string]: true } } = {};
+        cardinalityHash[dim.name] = {};
+        data.forEach((datapoint) => {
+          const dimValue = datapoint[dim.name];
+          cardinalityHash[dim.name][dimValue] = true;
         });
 
-        selectedDimensions = dimensions
-            .sort((a, b) => a.cardinality - b.cardinality)
-            .filter((data, index) => index === 0)
-            .map(dim => dim.name);
-    }
+        const dimKeys = Object.keys(cardinalityHash[dim.name]);
 
-    const finalChartSettings = {
-        metric1: (metrics[0] && metrics[0].name) || "none",
-        metric2: (metrics[1] && metrics[1].name) || "none",
-        metric3: "none",
-        metric4: "none",
-        dim1: (dimensions[0] && dimensions[0].name) || "none",
-        dim2: (dimensions[1] && dimensions[1].name) || "none",
-        dim3: "none",
-        timeseriesSort: "array-order",
-        networkLabel: "none",
-        ...chart
+        dim.cardinality = dimKeys.length;
+        dim.cardinalValues = dimKeys;
+      }
+      if (dim.unfilteredCardinality === 0) {
+        if (!filteredData) {
+          dim.unfilteredCardinality = dim.cardinality;
+          dim.unfilteredCardinalValues = dim.cardinalValues;
+        }
+        const cardinalityHash: { [key: string]: { [key: string]: true } } = {};
+        cardinalityHash[dim.name] = {};
+        props.data.data.forEach((datapoint) => {
+          const dimValue = datapoint[dim.name];
+          cardinalityHash[dim.name][dimValue] = true;
+        });
+
+        const dimKeys = Object.keys(cardinalityHash[dim.name]);
+
+        dim.unfilteredCardinality = dimKeys.length;
+        dim.unfilteredCardinalValues = dimKeys;
+      }
+    });
+
+    selectedDimensions = dimensions
+      .sort((a, b) => a.cardinality - b.cardinality)
+      .filter((data, index) => index === 0)
+      .map((dim) => dim.name);
+  }
+
+  const finalChartSettings = {
+    metric1: (metrics[0] && metrics[0].name) || "none",
+    metric2: (metrics[1] && metrics[1].name) || "none",
+    metric3: "none",
+    metric4: "none",
+    dim1: (dimensions[0] && dimensions[0].name) || "none",
+    dim2: (dimensions[1] && dimensions[1].name) || "none",
+    dim3: "none",
+    timeseriesSort: "array-order",
+    networkLabel: "none",
+    ...chart,
+  };
+
+  const displayChart: DisplayChart = {};
+  let newState: State = {
+    largeDataset,
+    view: existingView || initialView,
+    lineType: "line",
+    areaType: "hexbin",
+    trendLine: "none",
+    marginalGraphics: "none",
+    barGrouping: "Clustered",
+    selectedDimensions,
+    selectedMetrics: [],
+    pieceType: "bar",
+    summaryType: "violin",
+    networkType: "force",
+    hierarchyType: "dendrogram",
+    dimensions,
+    metrics,
+    colors,
+    // ui: {},
+    chart: finalChartSettings,
+    overrideSettings,
+    displayChart,
+    primaryKey,
+    data,
+    editable: true,
+    showLegend: true,
+    facets,
+    schema: props.data.schema,
+    props,
+  };
+
+  if (!filteredData) {
+    newState = {
+      ...newState,
+      ...nonChartDXSettings,
     };
+  } else {
+    newState = {
+      ...newState,
+      ...nonChartDXSettings,
+      metrics,
+      dimensions,
+      data,
+    };
+  }
 
-    const displayChart: DisplayChart = {};
-    let newState: State = {
-        largeDataset,
-        view: existingView || initialView,
-        lineType: "line",
-        areaType: "hexbin",
-        trendLine: "none",
-        marginalGraphics: "none",
-        barGrouping: "Clustered",
-        selectedDimensions,
-        selectedMetrics: [],
-        pieceType: "bar",
-        summaryType: "violin",
-        networkType: "force",
-        hierarchyType: "dendrogram",
-        dimensions,
-        metrics,
-        colors,
-        // ui: {},
-        chart: finalChartSettings,
-        overrideSettings,
-        displayChart,
-        primaryKey,
-        data,
-        editable: true,
-        showLegend: true,
-        facets,
-        schema: props.data.schema,
-        props
-    }
-
-    if (!filteredData) {
-        newState = {
-            ...newState,
-            ...nonChartDXSettings
-        }
-    } else {
-        newState = {
-            ...newState,
-            ...nonChartDXSettings,
-            metrics,
-            dimensions,
-            data
-        }
-    }
-
-    return newState
-}
+  return newState;
+};
 
 class DataExplorer extends React.PureComponent<Partial<Props>, State> {
-    static MIMETYPE: Props["mediaType"] = mediaType;
+  static MIMETYPE: Props["mediaType"] = mediaType;
 
-    static defaultProps = {
-        metadata: {
-            dx: {}
-        },
-        height: 500,
-        mediaType,
-        initialView: "grid",
-        overrideSettings: {},
-        additionalViews: {}
+  static defaultProps = {
+    metadata: {
+      dx: {},
+    },
+    height: 500,
+    mediaType,
+    initialView: "grid",
+    overrideSettings: {},
+    additionalViews: {},
+  };
+
+  constructor(props: Props) {
+    super(props);
+
+    this.state = processInitialData(props);
+  }
+
+  componentDidMount() {
+    this.updateChart(this.state);
+  }
+
+  filterData = (filterFn: Function, useBaseData?: boolean) => {
+    const { data, props, view, metrics, dimensions, ...remainingState } =
+      this.state;
+
+    if (!filterFn) {
+      this.updateChart(processInitialData(props, view, remainingState));
+      return;
+    }
+
+    const { filteredData = data } = this.state;
+    let newFilteredData: Dx.Datapoint[] = [];
+
+    if (useBaseData) {
+      newFilteredData = filterFn(props.data.data);
+    } else {
+      newFilteredData = filterFn(filteredData);
+    }
+
+    const newState = processInitialData(
+      props,
+      view,
+      this.state,
+      newFilteredData,
+    );
+
+    this.updateChart(newState);
+  };
+
+  updateChart = (updatedState: Partial<State>) => {
+    const {
+      view,
+      dimensions,
+      metrics,
+      chart,
+      lineType,
+      areaType,
+      selectedDimensions,
+      selectedMetrics,
+      pieceType,
+      summaryType,
+      networkType,
+      hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
+      colors,
+      primaryKey,
+      editable,
+      showLegend,
+      data: stateData,
+      facets,
+      overrideSettings,
+    } = { ...this.state, ...updatedState };
+
+    if (!this.props.data && !this.props.metadata) {
+      return;
+    }
+
+    let instantiatedView;
+
+    const {
+      data,
+      height,
+      OverrideVizControls,
+      OverrideLegend,
+      additionalViews,
+    } = this.props;
+
+    const chartKey = generateChartKey({
+      view,
+      lineType,
+      areaType,
+      selectedDimensions,
+      selectedMetrics,
+      pieceType,
+      summaryType,
+      networkType,
+      hierarchyType,
+      chart,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
+    });
+
+    const extendedSettings: SemioticSettings = {
+      ...semioticSettings,
+      ...additionalViews,
     };
 
-    constructor(props: Props) {
-        super(props);
+    if (!view || view === "grid") {
+      instantiatedView = (
+        <DataResourceTransformGrid {...(this.props as Props)} />
+      );
+    } else {
+      const { Frame, chartGenerator } = extendedSettings[view];
 
-        this.state = processInitialData(props);
+      const chartSettings = {
+        metrics,
+        dimensions,
+        chart,
+        colors,
+        height,
+        lineType,
+        areaType,
+        selectedDimensions,
+        selectedMetrics,
+        pieceType,
+        summaryType,
+        networkType,
+        hierarchyType,
+        primaryKey,
+        trendLine,
+        marginalGraphics,
+        barGrouping,
+        setColor: this.setColor,
+        filterData: this.filterData,
+        showLegend,
+      };
+
+      const baseFrameSettings = chartGenerator(
+        stateData,
+        data!.schema,
+        chartSettings,
+      );
+
+      const { frameSettings } = baseFrameSettings;
+
+      const frameOverride =
+        typeof overrideSettings === "function"
+          ? overrideSettings(chartSettings, baseFrameSettings, data, view)
+          : overrideSettings;
+
+      instantiatedView = (
+        <Frame
+          responsiveWidth
+          size={defaultResponsiveSize}
+          {...frameSettings}
+          {...frameOverride}
+        />
+      );
     }
 
-    componentDidMount() {
-        this.updateChart(this.state);
-    }
+    let finalRenderedViz;
 
-    filterData = (filterFn: Function, useBaseData?: boolean) => {
-
-        const { data, props, view, metrics, dimensions, ...remainingState } = this.state
-
-        if (!filterFn) {
-            this.updateChart(processInitialData(props, view, remainingState))
-            return
-        }
-
-        const { filteredData = data } = this.state
-        let newFilteredData: Dx.Datapoint[] = []
-
-        if (useBaseData) {
-            newFilteredData = filterFn(props.data.data)
-        } else {
-            newFilteredData = filterFn(filteredData)
-        }
-
-        const newState = processInitialData(props, view, this.state, newFilteredData)
-
-        this.updateChart(newState);
-
-    }
-
-    updateChart = (updatedState: Partial<State>) => {
+    if (facets && facets.length > 0) {
+      let colorHashOverride: any;
+      let colorDimOverride: any;
+      const facetFrames: React.ReactElement[] = [];
+      facets.forEach((baseDXSettings, facetIndex) => {
         const {
-            view,
-            dimensions,
+          dimFacet,
+          initialView = view,
+          data: facetDataSettings = this.state,
+          metadata: facetMetadata = { dx: {} },
+        } = baseDXSettings;
+
+        if (initialView === "grid") {
+          const facetGridProps = { ...this.props, ...baseDXSettings };
+
+          facetFrames.push(
+            <DataResourceTransformGrid {...(facetGridProps as Props)} />,
+          );
+        } else {
+          const { dx: facetDX = {} } = facetMetadata;
+
+          const { FacetFrame, chartGenerator: facetChartGenerator } =
+            extendedSettings[initialView];
+
+          const { data: facetData, schema: facetSchema } = facetDataSettings;
+
+          const filteredFacetData = dimFacet
+            ? facetData.filter((d) => d[dimFacet.dim] === dimFacet.value)
+            : facetData;
+
+          const title = dimFacet ? `${dimFacet.dim}=${dimFacet.value}` : "";
+
+          const facetChartSettings = {
             metrics,
-            chart,
+            dimensions,
+            chart: { ...chart, ...facetDX },
+            colors,
+            height,
             lineType,
             areaType,
             selectedDimensions,
@@ -471,438 +633,353 @@ class DataExplorer extends React.PureComponent<Partial<Props>, State> {
             summaryType,
             networkType,
             hierarchyType,
-            trendLine,
-            marginalGraphics,
-            barGrouping,
-            colors,
             primaryKey,
-            editable,
+            trendLine,
+            marginalGraphics,
+            barGrouping,
+            setColor: this.setColor,
+            filterData: this.filterData,
             showLegend,
-            data: stateData,
-            facets,
-            overrideSettings,
-        } = { ...this.state, ...updatedState };
+            ...facetDX,
+          };
 
-        if (!this.props.data && !this.props.metadata) {
-            return;
-        }
+          const facetFrameSettings = facetChartGenerator(
+            filteredFacetData,
+            facetSchema,
+            facetChartSettings,
+            colorHashOverride,
+            colorDimOverride,
+          );
 
-        let instantiatedView
+          const { colorHash, frameSettings, colorDim } = facetFrameSettings;
 
-        const { data, height, OverrideVizControls, OverrideLegend, additionalViews } = this.props;
+          colorHashOverride = colorHashOverride || colorHash;
+          colorDimOverride = colorDimOverride || colorDim;
 
-        const chartKey = generateChartKey({
-            view,
-            lineType,
-            areaType,
-            selectedDimensions,
-            selectedMetrics,
-            pieceType,
-            summaryType,
-            networkType,
-            hierarchyType,
-            chart,
-            trendLine,
-            marginalGraphics,
-            barGrouping
-        });
+          const facetOverride =
+            typeof overrideSettings === "function"
+              ? overrideSettings(
+                  facetChartSettings,
+                  facetFrameSettings,
+                  facetDataSettings,
+                  view,
+                )
+              : overrideSettings;
 
-        const extendedSettings: SemioticSettings = { ...semioticSettings, ...additionalViews }
-
-        if (!view || view === "grid") {
-            instantiatedView = <DataResourceTransformGrid {...this.props as Props} />
-        } else {
-            const { Frame, chartGenerator } = extendedSettings[view];
-
-            const chartSettings = {
-                metrics,
-                dimensions,
-                chart,
-                colors,
-                height,
-                lineType,
-                areaType,
-                selectedDimensions,
-                selectedMetrics,
-                pieceType,
-                summaryType,
-                networkType,
-                hierarchyType,
-                primaryKey,
-                trendLine,
-                marginalGraphics,
-                barGrouping,
-                setColor: this.setColor,
-                filterData: this.filterData,
-                showLegend
-            }
-
-            const baseFrameSettings = chartGenerator(stateData, data!.schema, chartSettings);
-
-            const { frameSettings } = baseFrameSettings
-
-            const frameOverride = typeof overrideSettings === "function" ? overrideSettings(chartSettings, baseFrameSettings, data, view) : overrideSettings
-
-            instantiatedView = <Frame
-                responsiveWidth
-                size={defaultResponsiveSize}
-                {...frameSettings}
-                {...frameOverride}
-
-            />
-        }
-
-        let finalRenderedViz
-
-        if (facets && facets.length > 0) {
-            let colorHashOverride: any;
-            let colorDimOverride: any;
-            const facetFrames: React.ReactElement[] = [];
-            facets
-                .forEach((baseDXSettings, facetIndex) => {
-
-                    const { dimFacet, initialView = view, data: facetDataSettings = this.state, metadata: facetMetadata = { dx: {} } } = baseDXSettings
-
-                    if (initialView === "grid") {
-                        const facetGridProps = { ...this.props, ...baseDXSettings }
-
-                        facetFrames.push(<DataResourceTransformGrid {...facetGridProps as Props} />)
-                    } else {
-                        const { dx: facetDX = {} } = facetMetadata
-
-                        const { FacetFrame, chartGenerator: facetChartGenerator } = extendedSettings[initialView];
-
-                        const { data: facetData, schema: facetSchema } = facetDataSettings
-
-                        const filteredFacetData = dimFacet ? facetData.filter(d => d[dimFacet.dim] === dimFacet.value) : facetData
-
-                        const title = dimFacet ? `${dimFacet.dim}=${dimFacet.value}` : ""
-
-                        const facetChartSettings = {
-                            metrics,
-                            dimensions,
-                            chart: { ...chart, ...facetDX },
-                            colors,
-                            height,
-                            lineType,
-                            areaType,
-                            selectedDimensions,
-                            selectedMetrics,
-                            pieceType,
-                            summaryType,
-                            networkType,
-                            hierarchyType,
-                            primaryKey,
-                            trendLine,
-                            marginalGraphics,
-                            barGrouping,
-                            setColor: this.setColor,
-                            filterData: this.filterData,
-                            showLegend,
-                            ...facetDX
-                        }
-
-                        const facetFrameSettings = facetChartGenerator(filteredFacetData, facetSchema, facetChartSettings, colorHashOverride, colorDimOverride)
-
-                        const { colorHash, frameSettings, colorDim } = facetFrameSettings
-
-                        colorHashOverride = colorHashOverride || colorHash
-                        colorDimOverride = colorDimOverride || colorDim
-
-                        const facetOverride = typeof overrideSettings === "function" ? overrideSettings(facetChartSettings, facetFrameSettings, facetDataSettings, view) : overrideSettings
-
-                        facetFrames.push(<FacetFrame
-                            {...frameSettings}
-                            beforeElements={<FacetControls
-                                focusFunction={(dxSettings: any) => {
-                                    this.updateChart({ chart: { ...chart, ...dxSettings.dx }, view: initialView, facets: [] });
-                                }}
-                                removeFunction={(facetIndex: any) => { this.updateChart({ facets: facets.filter((d, i) => i !== facetIndex) }) }}
-                                dxSettings={facetMetadata}
-                                facetIndex={facetIndex}
-                            />}
-                            size={defaultResponsiveSize}
-                            afterElements={null}
-                            margin={{ ...frameSettings.margin, ...{ left: 55, right: 25, top: 25 } }}
-                            title={title}
-                            {...facetOverride}
-                        />)
-                    }
-                })
-
-            const ActualLegend = OverrideLegend ? OverrideLegend : HTMLLegend
-
-
-            finalRenderedViz = <FacetWrapper>
-                <FacetController>
-                    {facetFrames}
-                </FacetController>
-                <ActualLegend
-                    valueHash={{}}
-                    colorHash={colorHashOverride}
-                    setColor={this.setColor}
-                    colors={colors}
+          facetFrames.push(
+            <FacetFrame
+              {...frameSettings}
+              beforeElements={
+                <FacetControls
+                  focusFunction={(dxSettings: any) => {
+                    this.updateChart({
+                      chart: { ...chart, ...dxSettings.dx },
+                      view: initialView,
+                      facets: [],
+                    });
+                  }}
+                  removeFunction={(facetIndex: any) => {
+                    this.updateChart({
+                      facets: facets.filter((d, i) => i !== facetIndex),
+                    });
+                  }}
+                  dxSettings={facetMetadata}
+                  facetIndex={facetIndex}
                 />
-            </FacetWrapper>
-        } else {
-
-            const controlProps = {
-                data: stateData,
-                view,
-                chart,
-                metrics,
-                dimensions,
-                selectedDimensions,
-                selectedMetrics,
-                hierarchyType,
-                summaryType,
-                networkType,
-                trendLine,
-                marginalGraphics,
-                barGrouping,
-                lineType,
-                areaType,
-                setAreaType: this.setAreaType,
-                updateChart: this.updateChart,
-                updateDimensions: this.updateDimensions,
-                setLineType: this.setLineType,
-                updateMetrics: this.updateMetrics,
-                generateFacets: this.generateFacets,
-                filterData: this.filterData,
-                setColor: this.setColor
-            }
-
-            const ActualVizControls = OverrideVizControls ? OverrideVizControls : VizControls
-
-            finalRenderedViz = <React.Fragment>{instantiatedView}
-                {editable && <ActualVizControls
-                    {...controlProps} />}</React.Fragment>
+              }
+              size={defaultResponsiveSize}
+              afterElements={null}
+              margin={{
+                ...frameSettings.margin,
+                ...{ left: 55, right: 25, top: 25 },
+              }}
+              title={title}
+              {...facetOverride}
+            />,
+          );
         }
+      });
 
-        const display: React.ReactNode = (
-            <SemioticWrapper>
-                {finalRenderedViz}
-            </SemioticWrapper>
-        );
+      const ActualLegend = OverrideLegend ? OverrideLegend : HTMLLegend;
 
-        // If you pass an onMetadataChange function, then fire it and pass the updated dx settings so someone upstream can update the metadata or otherwise use it
+      finalRenderedViz = (
+        <FacetWrapper>
+          <FacetController>{facetFrames}</FacetController>
+          <ActualLegend
+            valueHash={{}}
+            colorHash={colorHashOverride}
+            setColor={this.setColor}
+            colors={colors}
+          />
+        </FacetWrapper>
+      );
+    } else {
+      const controlProps = {
+        data: stateData,
+        view,
+        chart,
+        metrics,
+        dimensions,
+        selectedDimensions,
+        selectedMetrics,
+        hierarchyType,
+        summaryType,
+        networkType,
+        trendLine,
+        marginalGraphics,
+        barGrouping,
+        lineType,
+        areaType,
+        setAreaType: this.setAreaType,
+        updateChart: this.updateChart,
+        updateDimensions: this.updateDimensions,
+        setLineType: this.setLineType,
+        updateMetrics: this.updateMetrics,
+        generateFacets: this.generateFacets,
+        filterData: this.filterData,
+        setColor: this.setColor,
+      };
 
-        this.updateMetadata({
-            view,
-            lineType,
-            areaType,
-            selectedDimensions,
-            selectedMetrics,
-            pieceType,
-            summaryType,
-            networkType,
-            hierarchyType,
-            trendLine,
-            marginalGraphics,
-            barGrouping,
-            colors,
-            chart
-        });
+      const ActualVizControls = OverrideVizControls
+        ? OverrideVizControls
+        : VizControls;
 
-        this.setState(
-            (prevState): any => {
-                return {
-                    ...updatedState,
-                    displayChart: {
-                        ...prevState.displayChart,
-                        [chartKey]: display
-                    }
-                };
-            }
-        );
-    };
-
-    setView = (view: View) => {
-        this.updateChart({ view });
-    };
-
-    updateMetadata = (overrideProps: object) => {
-
-        const { onMetadataChange, metadata } = this.props;
-        const {
-            view,
-            lineType,
-            areaType,
-            selectedDimensions,
-            selectedMetrics,
-            pieceType,
-            summaryType,
-            networkType,
-            hierarchyType,
-            trendLine,
-            marginalGraphics,
-            barGrouping,
-            colors,
-            chart,
-            facets
-        } = this.state;
-        if (onMetadataChange) {
-            onMetadataChange(
-                {
-                    ...metadata,
-                    dx: {
-                        view,
-                        lineType,
-                        areaType,
-                        selectedDimensions,
-                        selectedMetrics,
-                        pieceType,
-                        summaryType,
-                        networkType,
-                        hierarchyType,
-                        trendLine,
-                        marginalGraphics,
-                        barGrouping,
-                        colors,
-                        chart,
-                        facets,
-                        ...overrideProps
-                    }
-                },
-                mediaType
-            );
-        }
-    };
-
-    setGrid = () => {
-        this.updateChart({ view: "grid" });
-    };
-
-    setColor = (newColorArray: string[]) => {
-        this.updateChart({ colors: newColorArray });
-    };
-
-    setLineType = (selectedLineType: LineType) => {
-        this.updateChart({ lineType: selectedLineType });
-    };
-
-    setAreaType = (selectedAreaType: AreaType) => {
-        this.updateChart({ areaType: selectedAreaType });
-    };
-
-    updateDimensions = (selectedDimension: string) => {
-        const oldDims = this.state.selectedDimensions;
-        const newDimensions =
-            oldDims.indexOf(selectedDimension) === -1
-                ? [...oldDims, selectedDimension]
-                : oldDims.filter(dimension => dimension !== selectedDimension);
-        this.updateChart({ selectedDimensions: newDimensions });
-    };
-
-    updateMetrics = (selectedMetric: string) => {
-        const oldMetrics = this.state.selectedMetrics;
-        const newMetrics =
-            oldMetrics.indexOf(selectedMetric) === -1
-                ? [...oldMetrics, selectedMetric]
-                : oldMetrics.filter(metric => metric !== selectedMetric);
-        this.updateChart({ selectedMetrics: newMetrics });
-    };
-
-    generateFacets = (name: string) => (onWhat: "dimension" | "metric" | "vizType", which?: string) => {
-        if (onWhat === "metric") {
-            const generatedFacets = this.state.metrics.map(metric => {
-                return {
-                    metadata: {
-                        dx: {
-                            [name]: metric.name
-                        }
-                    }
-                }
-            })
-
-            this.updateChart({ facets: generatedFacets });
-
-        }
-    };
-
-    render() {
-        const {
-            view,
-            dimensions,
-            metrics,
-            chart,
-            lineType,
-            areaType,
-            selectedDimensions,
-            selectedMetrics,
-            pieceType,
-            summaryType,
-            networkType,
-            hierarchyType,
-            trendLine,
-            marginalGraphics,
-            barGrouping,
-            largeDataset,
-            facets
-        } = this.state;
-
-        const { additionalViews } = this.props
-
-        let display: React.ReactNode = null;
-
-        if (semioticSettings[view] || view === "grid" || (additionalViews && additionalViews[view])) {
-
-            const chartKey = generateChartKey({
-                view,
-                lineType,
-                areaType,
-                selectedDimensions,
-                selectedMetrics,
-                pieceType,
-                summaryType,
-                networkType,
-                hierarchyType,
-                chart,
-                trendLine,
-                marginalGraphics,
-                barGrouping
-            });
-
-            display = this.state.displayChart[chartKey];
-        }
-
-        const toolbarProps = {
-            dimensions,
-            metrics,
-            currentView: view,
-            setGrid: this.setGrid,
-            setView: this.setView,
-            largeDataset
-        };
-
-        let children = React.Children.map(this.props.children, child => {
-            if (!React.isValidElement(child)) {
-                return;
-            }
-            const { componentType } = child.props as any;
-            if (componentType === "viz") {
-                const newProps = { children: display };
-                return React.cloneElement(child, newProps);
-            } else if (componentType === "toolbar") {
-                return React.cloneElement(child, toolbarProps);
-            }
-
-            return child;
-        });
-
-        return (
-            <div>
-                <MetadataWarning metadata={this.props.metadata!} />
-                <FlexWrapper>{
-                    children ? children :
-                        <>
-                            <Viz>{display}</Viz>
-                            {(!facets || facets.length === 0) && <Toolbar {...toolbarProps} />}
-                        </>
-                }</FlexWrapper>
-            </div>
-        );
+      finalRenderedViz = (
+        <React.Fragment>
+          {instantiatedView}
+          {editable && <ActualVizControls {...controlProps} />}
+        </React.Fragment>
+      );
     }
+
+    const display: React.ReactNode = (
+      <SemioticWrapper>{finalRenderedViz}</SemioticWrapper>
+    );
+
+    // If you pass an onMetadataChange function, then fire it and pass the updated dx settings so someone upstream can update the metadata or otherwise use it
+
+    this.updateMetadata({
+      view,
+      lineType,
+      areaType,
+      selectedDimensions,
+      selectedMetrics,
+      pieceType,
+      summaryType,
+      networkType,
+      hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
+      colors,
+      chart,
+    });
+
+    this.setState((prevState): any => {
+      return {
+        ...updatedState,
+        displayChart: {
+          ...prevState.displayChart,
+          [chartKey]: display,
+        },
+      };
+    });
+  };
+
+  setView = (view: View) => {
+    this.updateChart({ view });
+  };
+
+  updateMetadata = (overrideProps: object) => {
+    const { onMetadataChange, metadata } = this.props;
+    const {
+      view,
+      lineType,
+      areaType,
+      selectedDimensions,
+      selectedMetrics,
+      pieceType,
+      summaryType,
+      networkType,
+      hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
+      colors,
+      chart,
+      facets,
+    } = this.state;
+    if (onMetadataChange) {
+      onMetadataChange(
+        {
+          ...metadata,
+          dx: {
+            view,
+            lineType,
+            areaType,
+            selectedDimensions,
+            selectedMetrics,
+            pieceType,
+            summaryType,
+            networkType,
+            hierarchyType,
+            trendLine,
+            marginalGraphics,
+            barGrouping,
+            colors,
+            chart,
+            facets,
+            ...overrideProps,
+          },
+        },
+        mediaType,
+      );
+    }
+  };
+
+  setGrid = () => {
+    this.updateChart({ view: "grid" });
+  };
+
+  setColor = (newColorArray: string[]) => {
+    this.updateChart({ colors: newColorArray });
+  };
+
+  setLineType = (selectedLineType: LineType) => {
+    this.updateChart({ lineType: selectedLineType });
+  };
+
+  setAreaType = (selectedAreaType: AreaType) => {
+    this.updateChart({ areaType: selectedAreaType });
+  };
+
+  updateDimensions = (selectedDimension: string) => {
+    const oldDims = this.state.selectedDimensions;
+    const newDimensions =
+      oldDims.indexOf(selectedDimension) === -1
+        ? [...oldDims, selectedDimension]
+        : oldDims.filter((dimension) => dimension !== selectedDimension);
+    this.updateChart({ selectedDimensions: newDimensions });
+  };
+
+  updateMetrics = (selectedMetric: string) => {
+    const oldMetrics = this.state.selectedMetrics;
+    const newMetrics =
+      oldMetrics.indexOf(selectedMetric) === -1
+        ? [...oldMetrics, selectedMetric]
+        : oldMetrics.filter((metric) => metric !== selectedMetric);
+    this.updateChart({ selectedMetrics: newMetrics });
+  };
+
+  generateFacets =
+    (name: string) =>
+    (onWhat: "dimension" | "metric" | "vizType", which?: string) => {
+      if (onWhat === "metric") {
+        const generatedFacets = this.state.metrics.map((metric) => {
+          return {
+            metadata: {
+              dx: {
+                [name]: metric.name,
+              },
+            },
+          };
+        });
+
+        this.updateChart({ facets: generatedFacets });
+      }
+    };
+
+  render() {
+    const {
+      view,
+      dimensions,
+      metrics,
+      chart,
+      lineType,
+      areaType,
+      selectedDimensions,
+      selectedMetrics,
+      pieceType,
+      summaryType,
+      networkType,
+      hierarchyType,
+      trendLine,
+      marginalGraphics,
+      barGrouping,
+      largeDataset,
+      facets,
+    } = this.state;
+
+    const { additionalViews } = this.props;
+
+    let display: React.ReactNode = null;
+
+    if (
+      semioticSettings[view] ||
+      view === "grid" ||
+      (additionalViews && additionalViews[view])
+    ) {
+      const chartKey = generateChartKey({
+        view,
+        lineType,
+        areaType,
+        selectedDimensions,
+        selectedMetrics,
+        pieceType,
+        summaryType,
+        networkType,
+        hierarchyType,
+        chart,
+        trendLine,
+        marginalGraphics,
+        barGrouping,
+      });
+
+      display = this.state.displayChart[chartKey];
+    }
+
+    const toolbarProps = {
+      dimensions,
+      metrics,
+      currentView: view,
+      setGrid: this.setGrid,
+      setView: this.setView,
+      largeDataset,
+    };
+
+    let children = React.Children.map(this.props.children, (child) => {
+      if (!React.isValidElement(child)) {
+        return;
+      }
+      const { componentType } = child.props as any;
+      if (componentType === "viz") {
+        const newProps = { children: display };
+        return React.cloneElement(child, newProps);
+      } else if (componentType === "toolbar") {
+        return React.cloneElement(child, toolbarProps);
+      }
+
+      return child;
+    });
+
+    return (
+      <div>
+        <MetadataWarning metadata={this.props.metadata!} />
+        <FlexWrapper>
+          {children ? (
+            children
+          ) : (
+            <>
+              <Viz>{display}</Viz>
+              {(!facets || facets.length === 0) && (
+                <Toolbar {...toolbarProps} />
+              )}
+            </>
+          )}
+        </FlexWrapper>
+      </div>
+    );
+  }
 }
 
-export { DataExplorer as default, DataExplorer }
+export { DataExplorer as default, DataExplorer };

--- a/src/components/FacetControls.tsx
+++ b/src/components/FacetControls.tsx
@@ -1,9 +1,23 @@
 import * as React from "react";
 
 export default function (props: any) {
-    const { removeFunction, focusFunction, dxSettings, facetIndex } = props
-    return <div>
-        <button onClick={() => { removeFunction(facetIndex) }}>Remove</button>
-        <button onClick={() => { focusFunction(dxSettings) }}>Focus</button>
+  const { removeFunction, focusFunction, dxSettings, facetIndex } = props;
+  return (
+    <div>
+      <button
+        onClick={() => {
+          removeFunction(facetIndex);
+        }}
+      >
+        Remove
+      </button>
+      <button
+        onClick={() => {
+          focusFunction(dxSettings);
+        }}
+      >
+        Focus
+      </button>
     </div>
+  );
 }

--- a/src/components/HTMLLegend.md
+++ b/src/components/HTMLLegend.md
@@ -1,42 +1,42 @@
 You need to send colors to the legend via a hash and an array of colors. Optionally, you can also send values via a hash. The `setColor` function will send out the updated array of colors.
 
 ```jsx
-
 const colorHash = {
-    "Australia and New Zealand": "#1441A0",
-    "Central and Eastern Europe": "#B3331D",
-    "Eastern Asia": "#088EB2",
-    "Latin America and Caribbean": "#4D430C",
-    "Middle East and Northern Africa": "#B86117",
-    "North America": "#E5C209",
-    "Other": "grey",
-    "Southeastern Asia": "#1DB390",
-    "Southern Asia": "#E479A8",
-    "Sub-Saharan Africa": "#417505",
-    "Western Europe": "#DA752E"
-}
+  "Australia and New Zealand": "#1441A0",
+  "Central and Eastern Europe": "#B3331D",
+  "Eastern Asia": "#088EB2",
+  "Latin America and Caribbean": "#4D430C",
+  "Middle East and Northern Africa": "#B86117",
+  "North America": "#E5C209",
+  Other: "grey",
+  "Southeastern Asia": "#1DB390",
+  "Southern Asia": "#E479A8",
+  "Sub-Saharan Africa": "#417505",
+  "Western Europe": "#DA752E",
+};
 
 const valueHash = {
-    "Australia and New Zealand": 100,
-    "Central and Eastern Europe": 88,
-    "Eastern Asia": 50,
-    "Latin America and Caribbean": 200,
-    "Middle East and Northern Africa": 230,
-    "North America": 17,
-    "Other": 999,
-    "Southeastern Asia": 500,
-    "Southern Asia": 10,
-    "Sub-Saharan Africa": 750,
-    "Western Europe": 400
-}
+  "Australia and New Zealand": 100,
+  "Central and Eastern Europe": 88,
+  "Eastern Asia": 50,
+  "Latin America and Caribbean": 200,
+  "Middle East and Northern Africa": 230,
+  "North America": 17,
+  Other: 999,
+  "Southeastern Asia": 500,
+  "Southern Asia": 10,
+  "Sub-Saharan Africa": 750,
+  "Western Europe": 400,
+};
 
-const changeFunction = (newColors) => {console.info(newColors)}
+const changeFunction = (newColors) => {
+  console.info(newColors);
+};
 
 <HTMLLegend
-    values={Object.keys(valueHash)}
-    colorHash={colorHash}
-    valueHash={valueHash}
-    setColor={changeFunction}
-/>
-
+  values={Object.keys(valueHash)}
+  colorHash={colorHash}
+  valueHash={valueHash}
+  setColor={changeFunction}
+/>;
 ```

--- a/src/components/HTMLLegend.tsx
+++ b/src/components/HTMLLegend.tsx
@@ -41,10 +41,10 @@ const HTMLLegend = ({
   values = Object.keys(colorHash),
   valueHash,
   colors = Object.values(colorHash),
-  setColor
+  setColor,
 }: HTMLLegendProps) => {
   const updateColorFn: (newColorArray: string[]) => void = (
-    newColorArray: string[]
+    newColorArray: string[],
   ) => {
     setColor(newColorArray);
   };
@@ -53,7 +53,7 @@ const HTMLLegend = ({
     <LegendWrapper>
       {(values.length > 18
         ? // limit the displayed values to the top 18 and bin everything else into Other
-        [...values.filter((d, index) => index < 18), "Other"]
+          [...values.filter((d, index) => index < 18), "Other"]
         : values
       ).map(
         (value, index) =>
@@ -61,7 +61,7 @@ const HTMLLegend = ({
             <LegendItemSpan key={`legend-item-${index}`}>
               <CircleSpan
                 style={{
-                  background: colorHash[value]
+                  background: colorHash[value],
                 }}
               />
               <span className="html-legend-item">{value}</span>
@@ -70,7 +70,7 @@ const HTMLLegend = ({
                 `(${valueHash[value]})`) ||
                 ""}
             </LegendItemSpan>
-          )
+          ),
       )}
       {setColor && (
         <PalettePicker colors={colors} updateColor={updateColorFn} />

--- a/src/components/IconButton.md
+++ b/src/components/IconButton.md
@@ -1,24 +1,26 @@
 ```jsx
-import {
-  TreeIcon
-} from "../utilities/icons";
+import { TreeIcon } from "../utilities/icons";
 
 <div>
-<IconButton
-  message={"Sample Button"}
-  onClick={() => {"Clicked a button"}}
-  title="Title of sample button"
-  selected={false}
->
+  <IconButton
+    message={"Sample Button"}
+    onClick={() => {
+      "Clicked a button";
+    }}
+    title="Title of sample button"
+    selected={false}
+  >
     <TreeIcon />
-</IconButton>
-<IconButton
-  message={"Sample Button"}
-  onClick={() => {"Clicked a button"}}
-  title="Title of sample button"
-  selected={true}
->
+  </IconButton>
+  <IconButton
+    message={"Sample Button"}
+    onClick={() => {
+      "Clicked a button";
+    }}
+    title="Title of sample button"
+    selected={true}
+  >
     <TreeIcon />
-</IconButton>
-</div>
+  </IconButton>
+</div>;
 ```

--- a/src/components/PalettePicker.md
+++ b/src/components/PalettePicker.md
@@ -2,9 +2,11 @@ Simple controls for selecting a new color for your legend. The `updateColor` pro
 
 ```jsx
 <PalettePicker
-    colors={["red", "green", "yellow", "blue"]}
-    selectedColor="red"
-    selectedPosition={0}
-    updateColor={colors => {console.info(colors)}}
+  colors={["red", "green", "yellow", "blue"]}
+  selectedColor="red"
+  selectedPosition={0}
+  updateColor={(colors) => {
+    console.info(colors);
+  }}
 />
 ```

--- a/src/components/PalettePicker.tsx
+++ b/src/components/PalettePicker.tsx
@@ -99,7 +99,7 @@ const PaletteButton = styled.button`
 class PalettePicker extends React.PureComponent<Props, State> {
   static defaultProps = {
     metadata: {},
-    height: 500
+    height: 500,
   };
 
   constructor(props: Props) {
@@ -108,14 +108,14 @@ class PalettePicker extends React.PureComponent<Props, State> {
       open: false,
       selectedColor: props.colors[0],
       selectedPosition: 0,
-      colors: props.colors.join(",\n")
+      colors: props.colors.join(",\n"),
     };
   }
 
   openClose = () => {
     this.setState({
       open: !this.state.open,
-      colors: this.props.colors.join(",\n")
+      colors: this.props.colors.join(",\n"),
     });
   };
 
@@ -132,7 +132,7 @@ class PalettePicker extends React.PureComponent<Props, State> {
 
   colorsFromTextarea = () => {
     const parsedTextValue = this.state.colors
-      .replace(/\"/g, "")
+      .replace(/"/g, "")
       .replace(/ /g, "")
       .replace(/\[/g, "")
       .replace(/\]/g, "")
@@ -214,7 +214,7 @@ class PalettePicker extends React.PureComponent<Props, State> {
         <PalettePickerWrapper>
           <a
             href={`http://projects.susielu.com/viz-palette?colors=[${colors
-              .map(d => `"${d}"`)
+              .map((d) => `"${d}"`)
               .join(",")}]&backgroundColor="white"&fontColor="black"`}
           >
             Evaluate This Palette with VIZ PALETTE

--- a/src/components/ParallelCoordinatesController.md
+++ b/src/components/ParallelCoordinatesController.md
@@ -1,64 +1,82 @@
 Because parallel coordinates is a very involved chart mode, there's a component for it.
 
 ```jsx
-
 const { data, schema } = largeVizData;
 
 const pcOptions = {
-    colors: ["#5ebf72", "#275b52", "#83c0e6", "#6a2786", "#d76bac", "#573f56", "#9679a6", "#db11ac", "#2580fe", "#2e21d0", "#ae73fb", "#a1b27d", "#76480d", "#da9f63", "#a51409", "#fd7450", "#0e6e00", "#00d618"],
-    chart: { dim1: "Region" },
-    primaryKey: ["index"],
-    metrics: [
-        {
-                "name": "index",
-                "type": "integer"
-            },
-            {
-                "name": "Happiness Rank",
-                "type": "integer"
-            },
-            {
-                "name": "Happiness Score",
-                "type": "number"
-            },
-            {
-                "name": "Standard Error",
-                "type": "number"
-            },
-            {
-                "name": "Economy (GDP per Capita)",
-                "type": "number"
-            },
-            {
-                "name": "Family",
-                "type": "number"
-            },
-            {
-                "name": "Health (Life Expectancy)",
-                "type": "number"
-            },
-            {
-                "name": "Freedom",
-                "type": "number"
-            },
-            {
-                "name": "Trust (Government Corruption)",
-                "type": "number"
-            },
-            {
-                "name": "Generosity",
-                "type": "number"
-            },
-            {
-                "name": "Dystopia Residual",
-                "type": "number"
-            }
-    ]
+  colors: [
+    "#5ebf72",
+    "#275b52",
+    "#83c0e6",
+    "#6a2786",
+    "#d76bac",
+    "#573f56",
+    "#9679a6",
+    "#db11ac",
+    "#2580fe",
+    "#2e21d0",
+    "#ae73fb",
+    "#a1b27d",
+    "#76480d",
+    "#da9f63",
+    "#a51409",
+    "#fd7450",
+    "#0e6e00",
+    "#00d618",
+  ],
+  chart: { dim1: "Region" },
+  primaryKey: ["index"],
+  metrics: [
+    {
+      name: "index",
+      type: "integer",
+    },
+    {
+      name: "Happiness Rank",
+      type: "integer",
+    },
+    {
+      name: "Happiness Score",
+      type: "number",
+    },
+    {
+      name: "Standard Error",
+      type: "number",
+    },
+    {
+      name: "Economy (GDP per Capita)",
+      type: "number",
+    },
+    {
+      name: "Family",
+      type: "number",
+    },
+    {
+      name: "Health (Life Expectancy)",
+      type: "number",
+    },
+    {
+      name: "Freedom",
+      type: "number",
+    },
+    {
+      name: "Trust (Government Corruption)",
+      type: "number",
+    },
+    {
+      name: "Generosity",
+      type: "number",
+    },
+    {
+      name: "Dystopia Residual",
+      type: "number",
+    },
+  ],
 };
 
 <ParallelCoordinatesController
-    data={data}
-    schema={schema}
-    options={pcOptions}
-/>
+  data={data}
+  schema={schema}
+  options={pcOptions}
+/>;
 ```

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
-import { DatabaseOcticon } from "@nteract/octicons"
-import * as React from "react"
+import { DatabaseOcticon } from "@nteract/octicons";
+import * as React from "react";
 
-import { chartHelpText } from "../chartmeta/chart-docs"
+import { chartHelpText } from "../chartmeta/chart-docs";
 import {
   BarChartIcon,
   BoxplotIcon,
@@ -10,23 +10,23 @@ import {
   NetworkIcon,
   ParallelCoordinatesIcon,
   ScatterplotIcon,
-  TreeIcon
-} from "../utilities/icons"
+  TreeIcon,
+} from "../utilities/icons";
 
-import { View } from "../utilities/types"
+import { View } from "../utilities/types";
 
-import { IconButton } from "./IconButton"
+import { IconButton } from "./IconButton";
 
-import styled from "styled-components"
+import styled from "styled-components";
 
 interface Props {
-  setGrid: () => void
-  dimensions: object[]
-  setView: (view: View) => void
-  currentView: string
+  setGrid: () => void;
+  dimensions: object[];
+  setView: (view: View) => void;
+  currentView: string;
   // How we tell the root DataExplorer to pass toolbar props to this component:
-  componentType: "toolbar"
-  largeDataset?: boolean
+  componentType: "toolbar";
+  largeDataset?: boolean;
 }
 
 const ToolbarWrapper = styled.div`
@@ -34,15 +34,15 @@ const ToolbarWrapper = styled.div`
   flex-flow: column nowrap;
   z-index: 1;
   padding: 5px;
-`
+`;
 
 Toolbar.defaultProps = {
   componentType: "toolbar",
   currentView: "",
   dimensions: [],
   setGrid: () => null,
-  setView: () => null
-}
+  setView: () => null,
+};
 
 export function Toolbar({
   dimensions,
@@ -50,7 +50,7 @@ export function Toolbar({
   setView,
   currentView,
   componentType,
-  largeDataset
+  largeDataset,
 }: Props) {
   return (
     <ToolbarWrapper className="dx-button-bar">
@@ -135,5 +135,5 @@ export function Toolbar({
         <LineChartIcon />
       </IconButton>
     </ToolbarWrapper>
-  )
+  );
 }

--- a/src/components/Viz.tsx
+++ b/src/components/Viz.tsx
@@ -20,7 +20,7 @@ function PlaceHolder() {
 
 export const Viz: React.FunctionComponent<Partial<Props>> = ({
   children,
-  componentType
+  componentType,
 }: Props) => {
   // In the future, the Viz component might be used for things like error boundaries
   return <FlexItem>{children}</FlexItem>;

--- a/src/components/VizControls.tsx
+++ b/src/components/VizControls.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
+import * as React from "react";
 
-import { ChartOptionTypes, controlHelpText } from "../chartmeta/chart-docs"
+import { ChartOptionTypes, controlHelpText } from "../chartmeta/chart-docs";
 
-import styled, { css } from "styled-components"
-import * as Dx from "../utilities/types"
+import styled, { css } from "styled-components";
+import * as Dx from "../utilities/types";
 
 const commonCSS = css`
   h2 {
@@ -18,12 +18,12 @@ const commonCSS = css`
     background-color: #d8e1e8 !important;
     background-image: none !important;
   }
-`
+`;
 
 const ControlWrapper = styled.div`
   margin-right: 30px;
   ${commonCSS}
-`
+`;
 
 const Wrapper = styled.div`
   display: flex;
@@ -31,7 +31,7 @@ const Wrapper = styled.div`
   justify-content: left;
   margin-bottom: 30px;
   ${commonCSS}
-`
+`;
 
 const metricDimSelector = (
   values: string[],
@@ -42,17 +42,17 @@ const metricDimSelector = (
   contextTooltip = "Help me help you help yourself",
   facetingFunction?: (
     onWhat: "dimension" | "metric" | "vizType",
-    which?: string
-  ) => void
+    which?: string,
+  ) => void,
 ) => {
-  const metricsList = required ? values : ["none", ...values]
-  let displayMetrics
+  const metricsList = required ? values : ["none", ...values];
+  let displayMetrics;
 
   if (metricsList.length > 1) {
     displayMetrics = (
       <select
         onChange={(event: { target: { value: string } }): void => {
-          selectionFunction(event.target.value)
+          selectionFunction(event.target.value);
         }}
         value={selectedValue}
       >
@@ -67,22 +67,22 @@ const metricDimSelector = (
           </option>
         ))}
       </select>
-    )
+    );
   } else {
-    displayMetrics = <p style={{ margin: 0 }}>{metricsList[0]}</p>
+    displayMetrics = <p style={{ margin: 0 }}>{metricsList[0]}</p>;
   }
 
-  let generateFacetButton
+  let generateFacetButton;
   if (facetingFunction) {
     generateFacetButton = (
       <button
         onClick={() => {
-          facetingFunction("metric", title)
+          facetingFunction("metric", title);
         }}
       >
         Facet
       </button>
-    )
+    );
   }
 
   return (
@@ -93,72 +93,72 @@ const metricDimSelector = (
       {displayMetrics}
       {generateFacetButton}
     </ControlWrapper>
-  )
-}
+  );
+};
 
 const availableLineTypes: Array<{
-  type: Dx.LineType
-  label: string
+  type: Dx.LineType;
+  label: string;
 }> = [
   {
     type: "line",
-    label: "Line Chart"
+    label: "Line Chart",
   },
   {
     type: "stackedarea",
-    label: "Stacked Area Chart"
+    label: "Stacked Area Chart",
   },
   {
     type: "stackedpercent",
-    label: "Stacked Area Chart (Percent)"
+    label: "Stacked Area Chart (Percent)",
   },
   {
     type: "bumparea",
-    label: "Ranked Area Chart"
-  }
-]
+    label: "Ranked Area Chart",
+  },
+];
 
 const availableAreaTypes = [
   {
     type: "hexbin",
-    label: "Hexbin"
+    label: "Hexbin",
   },
   {
     type: "heatmap",
-    label: "Heatmap"
+    label: "Heatmap",
   },
   {
     type: "contour",
-    label: "Contour Plot"
-  }
-]
+    label: "Contour Plot",
+  },
+];
 
-type ChartOptions = { [key in ChartOptionTypes]: string }
+type ChartOptions = { [key in ChartOptionTypes]: string };
 interface VizControlParams {
-  view: Dx.View
-  chart: Dx.Chart
-  metrics: Dx.Field[]
-  dimensions: Dx.Dimension[]
+  view: Dx.View;
+  chart: Dx.Chart;
+  metrics: Dx.Field[];
+  dimensions: Dx.Dimension[];
   // TODO: leave "options: any" for now and improve typedef later
-  updateChart: (options: any) => void
-  selectedDimensions: string[]
-  selectedMetrics: string[]
-  hierarchyType: Dx.HierarchyType
-  summaryType: Dx.SummaryType
-  networkType: string
-  setLineType: (lineType: Dx.LineType) => void
-  updateMetrics: (name: string) => void
+  updateChart: (options: any) => void;
+  selectedDimensions: string[];
+  selectedMetrics: string[];
+  hierarchyType: Dx.HierarchyType;
+  summaryType: Dx.SummaryType;
+  networkType: string;
+  setLineType: (lineType: Dx.LineType) => void;
+  updateMetrics: (name: string) => void;
   generateFacets: (
-    metricName: string
-  ) => (onWhat: "dimension" | "metric" | "vizType", which?: string) => void
-  updateDimensions: (name: string) => void
-  lineType: Dx.LineType
-  areaType: Dx.AreaType
-  setAreaType: (label: Dx.AreaType) => void
-  data: Dx.Datapoint[]
-  trendLine: Dx.TrendLineType
-  marginalGraphics: Dx.SummaryType
-  barGrouping: Dx.BarGroupingType
+    metricName: string,
+  ) => (onWhat: "dimension" | "metric" | "vizType", which?: string) => void;
+  updateDimensions: (name: string) => void;
+  lineType: Dx.LineType;
+  areaType: Dx.AreaType;
+  setAreaType: (label: Dx.AreaType) => void;
+  data: Dx.Datapoint[];
+  trendLine: Dx.TrendLineType;
+  marginalGraphics: Dx.SummaryType;
+  barGrouping: Dx.BarGroupingType;
 }
 export default ({
   view,
@@ -181,35 +181,35 @@ export default ({
   areaType,
   setAreaType,
   data,
-  generateFacets
+  generateFacets,
 }: VizControlParams) => {
-  const metricNames = metrics.map(metric => metric.name)
-  const dimensionNames = dimensions.map(dim => dim.name)
+  const metricNames = metrics.map((metric) => metric.name);
+  const dimensionNames = dimensions.map((dim) => dim.name);
 
   const updateChartGenerator = (chartProperty: string) => {
     return (metricOrDim: string) =>
-      updateChart({ chart: { ...chart, [chartProperty]: metricOrDim } })
-  }
+      updateChart({ chart: { ...chart, [chartProperty]: metricOrDim } });
+  };
 
   const getControlHelpText = (view: string, metricOrDim: string) => {
-    if (Object.keys(controlHelpText).find(mOrD => mOrD === metricOrDim)) {
-      const mOrD = metricOrDim as ChartOptionTypes
+    if (Object.keys(controlHelpText).find((mOrD) => mOrD === metricOrDim)) {
+      const mOrD = metricOrDim as ChartOptionTypes;
       const views =
-        controlHelpText[mOrD] !== undefined ? controlHelpText[mOrD] : null
+        controlHelpText[mOrD] !== undefined ? controlHelpText[mOrD] : null;
       if (views == null) {
-        return ""
+        return "";
       }
       if (typeof views === "string") {
-        return views
+        return views;
       }
       if (views[view] != null) {
-        return views[view]
+        return views[view];
       } else {
-        return views.default
+        return views.default;
       }
     }
-    return ""
-  }
+    return "";
+  };
 
   return (
     <React.Fragment>
@@ -227,7 +227,7 @@ export default ({
             true,
             chart.metric1,
             getControlHelpText(view, "metric1"),
-            generateFacets("metric1")
+            generateFacets("metric1"),
           )}
         {(view === "scatter" || view === "hexbin") &&
           metricDimSelector(
@@ -237,7 +237,7 @@ export default ({
             true,
             chart.metric2,
             getControlHelpText(view, "metric2"),
-            generateFacets("metric2")
+            generateFacets("metric2"),
           )}
         {((view === "scatter" && data.length < 1000) || view === "bar") &&
           metricDimSelector(
@@ -247,7 +247,7 @@ export default ({
             false,
             chart.metric3,
             getControlHelpText(view, "metric3"),
-            generateFacets("metric3")
+            generateFacets("metric3"),
           )}
         {view === "bar" &&
           metricDimSelector(
@@ -257,38 +257,38 @@ export default ({
             false,
             chart.metric4,
             getControlHelpText(view, "metric4"),
-            generateFacets("metric4")
+            generateFacets("metric4"),
           )}
         {view === "bar" &&
           metricDimSelector(
             ["Clustered", "Stacked"],
-            selectedBarGrouping =>
+            (selectedBarGrouping) =>
               updateChart({ barGrouping: selectedBarGrouping }),
             "Stack or Cluster",
             true,
             barGrouping,
-            controlHelpText.barGrouping as string
+            controlHelpText.barGrouping as string,
           )}
         {view === "scatter" &&
           metricDimSelector(
             ["boxplot", "violin", "heatmap", "ridgeline", "histogram"],
-            selectedMarginalGraphics =>
+            (selectedMarginalGraphics) =>
               updateChart({ marginalGraphics: selectedMarginalGraphics }),
             "Marginal Graphics",
             false,
             marginalGraphics,
-            controlHelpText.marginalGraphics as string
+            controlHelpText.marginalGraphics as string,
           )}
 
         {view === "scatter" &&
           metricDimSelector(
             ["linear", "polynomial", "power", "exponential", "logarithmic"],
-            selectedRegressionType =>
+            (selectedRegressionType) =>
               updateChart({ trendLine: selectedRegressionType }),
             "Trendline",
             false,
             trendLine,
-            controlHelpText.trendLine as string
+            controlHelpText.trendLine as string,
           )}
         {(view === "summary" ||
           view === "scatter" ||
@@ -301,7 +301,7 @@ export default ({
             view === "summary" ? "Category" : "Color",
             true,
             chart.dim1,
-            getControlHelpText(view, "dim1")
+            getControlHelpText(view, "dim1"),
           )}
         {view === "scatter" &&
           metricDimSelector(
@@ -310,7 +310,7 @@ export default ({
             "Labels",
             false,
             chart.dim2,
-            getControlHelpText(view, "dim2")
+            getControlHelpText(view, "dim2"),
           )}
         {view === "hexbin" &&
           areaType === "contour" &&
@@ -320,7 +320,7 @@ export default ({
             "Multiclass",
             false,
             chart.dim3,
-            getControlHelpText(view, "dim3")
+            getControlHelpText(view, "dim3"),
           )}
         {view === "network" &&
           metricDimSelector(
@@ -329,7 +329,7 @@ export default ({
             "SOURCE",
             true,
             chart.dim1,
-            getControlHelpText(view, "dim1")
+            getControlHelpText(view, "dim1"),
           )}
         {view === "network" &&
           metricDimSelector(
@@ -338,17 +338,17 @@ export default ({
             "TARGET",
             true,
             chart.dim2,
-            getControlHelpText(view, "dim2")
+            getControlHelpText(view, "dim2"),
           )}
         {view === "network" &&
           metricDimSelector(
             ["matrix", "arc", "force", "sankey"],
-            selectedNetworkType =>
+            (selectedNetworkType) =>
               updateChart({ networkType: selectedNetworkType }),
             "Type",
             true,
             networkType,
-            controlHelpText.networkType as string
+            controlHelpText.networkType as string,
           )}
         {view === "network" &&
           metricDimSelector(
@@ -357,27 +357,27 @@ export default ({
             "Show Labels",
             false,
             chart.networkLabel,
-            controlHelpText.networkLabel as string
+            controlHelpText.networkLabel as string,
           )}
         {view === "hierarchy" &&
           metricDimSelector(
             ["dendrogram", "treemap", "partition", "sunburst"],
-            selectedHierarchyType =>
+            (selectedHierarchyType) =>
               updateChart({ hierarchyType: selectedHierarchyType }),
             "Type",
             true,
             hierarchyType,
-            controlHelpText.hierarchyType as string
+            controlHelpText.hierarchyType as string,
           )}
         {view === "summary" &&
           metricDimSelector(
             ["violin", "boxplot", "ridgeline", "heatmap", "histogram"],
-            selectedSummaryType =>
+            (selectedSummaryType) =>
               updateChart({ summaryType: selectedSummaryType }),
             "Type",
             true,
             summaryType,
-            controlHelpText.summaryType as string
+            controlHelpText.summaryType as string,
           )}
         {view === "line" &&
           metricDimSelector(
@@ -386,7 +386,7 @@ export default ({
             "Sort by",
             true,
             chart.timeseriesSort,
-            controlHelpText.timeseriesSort as string
+            controlHelpText.timeseriesSort as string,
           )}
         {view === "line" && (
           <div
@@ -396,11 +396,12 @@ export default ({
             <div>
               <h3>Chart Type</h3>
             </div>
-            {availableLineTypes.map(lineTypeOption => (
+            {availableLineTypes.map((lineTypeOption) => (
               <button
                 key={lineTypeOption.type}
-                className={`button-text ${lineType === lineTypeOption.type &&
-                  "selected"}`}
+                className={`button-text ${
+                  lineType === lineTypeOption.type && "selected"
+                }`}
                 onClick={() => setLineType(lineTypeOption.type)}
               >
                 {lineTypeOption.label}
@@ -416,8 +417,8 @@ export default ({
             <div>
               <h3>Chart Type</h3>
             </div>
-            {availableAreaTypes.map(areaTypeOption => {
-              const areaTypeOptionType = areaTypeOption.type
+            {availableAreaTypes.map((areaTypeOption) => {
+              const areaTypeOptionType = areaTypeOption.type;
               if (
                 areaTypeOptionType === "contour" ||
                 areaTypeOptionType === "hexbin" ||
@@ -425,16 +426,17 @@ export default ({
               ) {
                 return (
                   <button
-                    className={`button-text ${areaType === areaTypeOptionType &&
-                      "selected"}`}
+                    className={`button-text ${
+                      areaType === areaTypeOptionType && "selected"
+                    }`}
                     key={areaTypeOptionType}
                     onClick={() => setAreaType(areaTypeOptionType)}
                   >
                     {areaTypeOption.label}
                   </button>
-                )
+                );
               } else {
-                return <div />
+                return <div />;
               }
             })}
           </div>
@@ -460,12 +462,12 @@ export default ({
             <div>
               <h3>Categories</h3>
             </div>
-            {dimensions.map(dim => (
+            {dimensions.map((dim) => (
               <button
                 key={`dimensions-select-${dim.name}`}
-                className={`button-text ${selectedDimensions.indexOf(
-                  dim.name
-                ) !== -1 && "selected"}`}
+                className={`button-text ${
+                  selectedDimensions.indexOf(dim.name) !== -1 && "selected"
+                }`}
                 onClick={() => updateDimensions(dim.name)}
               >
                 {dim.name}
@@ -481,12 +483,12 @@ export default ({
             <div>
               <h3>Metrics</h3>
             </div>
-            {metrics.map(metric => (
+            {metrics.map((metric) => (
               <button
                 key={`metrics-select-${metric.name}`}
-                className={`button-text ${selectedMetrics.indexOf(
-                  metric.name
-                ) !== -1 && "selected"}`}
+                className={`button-text ${
+                  selectedMetrics.indexOf(metric.name) !== -1 && "selected"
+                }`}
                 onClick={() => updateMetrics(metric.name)}
               >
                 {metric.name}
@@ -496,5 +498,5 @@ export default ({
         )}
       </Wrapper>
     </React.Fragment>
-  )
-}
+  );
+};

--- a/src/css/index.tsx
+++ b/src/css/index.tsx
@@ -10,23 +10,24 @@ interface ThemeProps {
 export default styled.div<ThemeProps>`
   /* React table style customization */
   width: 100%;
-  font-family: System-UI, -apple-system, BlinkMacSystemFont, "Source Sans Pro", sans-serif;
+  font-family: System-UI, -apple-system, BlinkMacSystemFont, "Source Sans Pro",
+    sans-serif;
   font-size: 0.875rem;
 
-
   .ReactTable .rt-thead.-header .rt-th {
-    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#1e1e1e" : "#f2f2f2")};
+    color: ${(props) => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${(props) =>
+      props.theme === "dark" ? "#1e1e1e" : "#f2f2f2"};
     padding: 2.5rem 0.75rem 0.5rem;
   }
   .ReactTable.-striped .rt-tr.-odd > div {
-    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#111" : "#fff")};
+    color: ${(props) => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${(props) => (props.theme === "dark" ? "#111" : "#fff")};
   }
 
   .ReactTable.-striped .rt-tr.-even > div {
-    color: ${props => (props.theme === "dark" ? "#bbb" : "#111")};
-    background-color: ${props => (props.theme === "dark" ? "#111" : "#fff")};
+    color: ${(props) => (props.theme === "dark" ? "#bbb" : "#111")};
+    background-color: ${(props) => (props.theme === "dark" ? "#111" : "#fff")};
   }
 
   .ReactTable.-highlight .rt-tbody .rt-tr:not(.-padRow):hover {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 
-export { DataExplorer as default, DataExplorer } from "./components/DataExplorer";
+export {
+  DataExplorer as default,
+  DataExplorer,
+} from "./components/DataExplorer";
 export { Toolbar } from "./components/Toolbar";
 export { Viz } from "./components/Viz";

--- a/src/utilities/settings.ts
+++ b/src/utilities/settings.ts
@@ -17,5 +17,5 @@ export const colors = [
   "#8DD2C2",
   "#E6A19F",
   "#3DC7E0",
-  "#98CE5B"
+  "#98CE5B",
 ];

--- a/src/utilities/tooltip-content.tsx
+++ b/src/utilities/tooltip-content.tsx
@@ -1,19 +1,19 @@
-import * as React from "react"
+import * as React from "react";
 
-import styled from "styled-components"
+import styled from "styled-components";
 
 interface Props {
-  x: number
-  y: number
+  x: number;
+  y: number;
 }
 
 export const safeDisplayValue = (value: any) =>
-  value && value.toString ? value.toString() : value
+  value && value.toString ? value.toString() : value;
 
 // A little "mixin" for picking the :before on a tooltip
 const beforeContent = (props: Props) => {
   if (props.x < 200 || props.x > 600) {
-    return null
+    return null;
   }
   if (props.y < 200) {
     return `
@@ -29,7 +29,7 @@ const beforeContent = (props: Props) => {
       height: 15px;
       position: absolute;
       z-index: 99;
-    `
+    `;
   }
 
   return `
@@ -45,16 +45,16 @@ const beforeContent = (props: Props) => {
     height: 15px;
     position: absolute;
     z-index: 99;
-  `
-}
+  `;
+};
 
 const TooltipContent = styled.div.attrs((props: Props) => ({
   style: {
     transform: `translate(
       ${props.x < 200 ? "0px" : props.x > 600 ? "-100%" : "calc(-50% + 7px)"},
       ${props.y < 200 ? "10px" : "calc(-100% - 10px)"}
-    )`
-  }
+    )`,
+  },
 }))`
   color: black;
   padding: 10px;
@@ -76,5 +76,5 @@ const TooltipContent = styled.div.attrs((props: Props) => ({
   &:before {
     ${beforeContent}
   }
-`
-export default TooltipContent
+`;
+export default TooltipContent;

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,4 +1,3 @@
-
 export interface Metric extends Field {
   type: "integer" | "datetime" | "number";
   extent: [any, any];
@@ -37,12 +36,11 @@ export interface DataProps {
 }
 
 export interface facetProps {
-  dimFacet?: { dim: string, value: string };
+  dimFacet?: { dim: string; value: string };
   data?: DataProps;
   metadata?: Metadata;
   initialView?: View;
 }
-
 
 export interface dxMetaProps {
   view?: View;
@@ -80,9 +78,15 @@ export interface Field {
   name: string;
   // Types are based on the json-schema standard, with some variations
   // https://specs.frictionlessdata.io/table-schema/#types-and-formats
-  type: 'string' | 'integer' | 'number' | 'boolean' | 'datetime' | 'object' | string; // Other types are permitted, but not explicitly handled
+  type:
+    | "string"
+    | "integer"
+    | "number"
+    | "boolean"
+    | "datetime"
+    | "object"
+    | string; // Other types are permitted, but not explicitly handled
 }
-
 
 export interface Datapoint {
   [fieldName: string]: any;
@@ -90,13 +94,12 @@ export interface Datapoint {
 
 export type SemioticSettings = {
   [fieldName: string]: {
-    Frame: Function,
-    controls: string,
-    chartGenerator: Function,
-    FacetFrame: Function
-  }
-}
-
+    Frame: Function;
+    controls: string;
+    chartGenerator: Function;
+    FacetFrame: Function;
+  };
+};
 
 export interface LineCoordinate {
   value: number;
@@ -166,7 +169,7 @@ export type JSONType = PrimitiveImmutable | JSONObject | JSONArray;
 export interface JSONObject {
   [key: string]: JSONType;
 }
-export interface JSONArray extends Array<JSONType> { }
+export interface JSONArray extends Array<JSONType> {}
 
 /**
  *

--- a/src/utilities/utilities.ts
+++ b/src/utilities/utilities.ts
@@ -13,5 +13,5 @@ export function numeralFormatting(tickValue: number): string {
 }
 
 export function createLabelItems(uniqueValues: string[]): any[] {
-  return uniqueValues.map(value => ({ label: value }));
+  return uniqueValues.map((value) => ({ label: value }));
 }


### PR DESCRIPTION
## Motivation

- Apply libraries that were added in #66 and #69 to the whole codebase at once so that new contributors won't find that their 1 line changes modify many more lines than they expected. Otherwise, those libraries would only be helping with new files. 

## Changes

- Sits on commits from #69 and #68 , those should be reviewed/merged first.
- Ran `yarn run format`, and committed the result.
- Temporarily permitting unused variables to just `warn` instead of `error` to avoid making this diff any larger. We can change the warning level in the future ( see https://github.com/nteract/data-explorer/blob/d73196ab729ab6d926587825a37a1863a36d54a7/.eslintrc.js#L14 )

## Testing

- CI should pass