### PR TITLE
fix: handle empty data in column cells gracefully to avoid viz-switching runtime errors

### DIFF
--- a/src/charts/bar.tsx
+++ b/src/charts/bar.tsx
@@ -5,7 +5,7 @@ import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content";
 import { numeralFormatting } from "../utilities/utilities";
 
 import * as Dx from "../utilities/types";
-import { sortByOrdinalRange } from "./shared";
+import { sortByOrdinalRange, getUniqueValues } from "./shared";
 
 interface BarOptions {
   selectedDimensions: string[];
@@ -112,15 +112,7 @@ export const semioticBarChart = (
     };
   }
 
-  const uniqueValues = sortedData.reduce(
-    (uniques, datapoint) =>
-      !uniques.find(
-        (uniqueDimName: string) => uniqueDimName === datapoint[dim1].toString(),
-      )
-        ? [...uniques, datapoint[dim1].toString()]
-        : uniques,
-    [],
-  );
+  const uniqueValues = dim1 === "none" ? [] : getUniqueValues(sortedData, dim1);
 
   if (!colorHashOverride && dim1 && dim1 !== "none") {
     uniqueValues.forEach((value: string, index: number) => {

--- a/src/charts/shared.tsx
+++ b/src/charts/shared.tsx
@@ -20,7 +20,7 @@ export const sortByOrdinalRange = (
   rAccessor: string | (() => void),
   secondarySort: string,
   data: Dx.DataProps["data"],
-): any[] => {
+): Dx.DataProps["data"] => {
   const subsortData: { [index: string]: SubsortObject } = {};
   let subsortArrays: SubsortObject[] = [];
   data.forEach((datapoint) => {
@@ -64,4 +64,23 @@ export const sortByOrdinalRange = (
     ],
     [],
   );
+};
+
+/*
+  Returns uniques values in a column as strings
+  Safely stringifies different data types, including null/undefined.
+*/
+export const getUniqueValues = (
+  points: Dx.DataProps["data"],
+  accessor: string,
+): string[] => {
+  return [
+    ...new Set(
+      points.map((d) => {
+        const value = d[accessor];
+        // Don't call stringify on a string, as it will add "quote" marks around your value.
+        return typeof value === "string" ? value : JSON.stringify(value);
+      }),
+    ),
+  ];
 };

--- a/src/charts/summary.tsx
+++ b/src/charts/summary.tsx
@@ -5,6 +5,7 @@ import HTMLLegend from "../components/HTMLLegend";
 import TooltipContent, { safeDisplayValue } from "../utilities/tooltip-content";
 import * as Dx from "../utilities/types";
 import { numeralFormatting } from "../utilities/utilities";
+import { getUniqueValues } from "./shared";
 
 interface SummaryOptions {
   chart: Dx.Chart;
@@ -37,14 +38,7 @@ export const semioticSummaryChart = (
 
   const rAccessor = metric1;
 
-  const uniqueValues = data.reduce(
-    (uniqueArray: string[], datapoint) =>
-      (!uniqueArray.find(
-        (dimValue: string) => dimValue === datapoint[dim1].toString(),
-      ) && [...uniqueArray, datapoint[dim1].toString()]) ||
-      uniqueArray,
-    [],
-  );
+  const uniqueValues = dim1 === "none" ? [] : getUniqueValues(data, dim1);
 
   if (!colorHashOverride && dim1 && dim1 !== "none") {
     uniqueValues.sort().forEach((dimValue, index) => {

--- a/src/charts/xyplot.tsx
+++ b/src/charts/xyplot.tsx
@@ -7,7 +7,7 @@ import TooltipContent from "../utilities/tooltip-content";
 import { numeralFormatting } from "../utilities/utilities";
 
 import * as Dx from "../utilities/types";
-import { sortByOrdinalRange } from "./shared";
+import { sortByOrdinalRange, getUniqueValues } from "./shared";
 
 import styled from "styled-components";
 
@@ -253,14 +253,7 @@ export const semioticXYPlot = (
     dim1 &&
     dim1 !== "none"
   ) {
-    const uniqueValues = sortedData.reduce(
-      (uniqueArray, datapoint) =>
-        (!uniqueArray.find(
-          (uniqueDim: string) => uniqueDim === datapoint[dim1].toString(),
-        ) && [...uniqueArray, datapoint[dim1].toString()]) ||
-        uniqueArray,
-      [],
-    );
+    const uniqueValues = getUniqueValues(sortedData, dim1);
 
     if (!colorHashOverride) {
       uniqueValues.sort().forEach((dimValue: string, index: number) => {


### PR DESCRIPTION
## Motivation

- I was encountering runtime errors that crashed the app when switching between visualizations, or visualizing data where some values were undefined.
- See this interactive video https://app.replay.io/?id=0f6f88ae-de51-464d-8978-331ce059985f for examples of how this could be triggered even with a very small dataset that contains non string/number cell types (like objects, I noticed this from testing #65 )
 - The above video was from a test with a 1 row dataset: https://codesandbox.io/s/priceless-goldwasser-bdfkn

## Changes

 - Use `JSON.stringify` instead of `.toString()`, this handles `null` and `undefined` gracefully (the previous error happens because those empty values don't have a `toString()` attached. We technically have the option of ignoring those values entirely, but it might be unexpected behavior depending on the user. 
- Use a `Set` to find unique values in each column rather than looping through the entire array twice as the previous `find` / `reduce` mechanism was doing.  


## Testing

- Repro instructions: load the codepen, and start switching visualization types
  - Before: https://codesandbox.io/s/priceless-goldwasser-bdfkn
  - After: https://codesandbox.io/s/nteract-data-explorer-issue-71-viz-switching-fix-uees1 (The app still does not have anything meaningful to show for an object type column, but at least it does not crash). 

- Note: switching to the line chart triggers a different sort of error, but I'll save that for a different investigation.

(GIF: https://a.cl.ly/qGu5nReq )
![Screen Recording 2021-07-10 at 09 27 11 PM](https://user-images.githubusercontent.com/9020979/125180231-b5cf4a00-e1c5-11eb-989e-31988b1645d0.gif)


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.2.12--canary.71.a7f202e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @nteract/data-explorer@8.2.12--canary.71.a7f202e.0
  # or 
  yarn add @nteract/data-explorer@8.2.12--canary.71.a7f202e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
