### PR TITLE
chore: update CI base branch from main -> next, document publish process

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -5,5 +5,6 @@
     "first-time-contributor",
     "released"
   ],
-  "onlyPublishWithReleaseLabel": true
+  "baseBranch": "stable",
+  "prereleaseBranches": ["next"]
 }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ main ]
+    branches: [ next ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ main ]
+    branches: [ next ]
   schedule:
     - cron: '40 23 * * 1'
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ next ]
   pull_request:
-    branches: [ main ]
+    branches: [ next ]
 
 jobs:
   build:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,10 @@ Consistent formatting allows us to keep the [changelog](./CHANGELOG.md) up to da
 
 ## Publishing
 
-Publishing is handled by a 2-branch [pre-release process](https://intuit.github.io/auto/docs/generated/shipit#next-branch-default), configured in `release.yml`. All changes should be based off of the default `next` branch. Changes are published when a `release` tag is included on the PR.
+Publishing is handled by a 2-branch [pre-release process](https://intuit.github.io/auto/docs/generated/shipit#next-branch-default), configured in `release.yml`. All changes should be based off of the default `next` branch. Changes are automatically published to the `next` channel on NPM unless set to ignore via a `skip-release` Github label.
 
-- To prevent a change from creating a release, use the `skip-release` label.
+
 - PRs made into the default branch are deployed to the `next` pre-release tag on NPM. The result can be installed with `npm install @nteract/data-explorer@next`.
   - When merging into `next`, please use the `create a merge commit` strategy. If `rebase` is used, auto won't be able to detect which PR introduced a particular set of commits..
-- To release a new stable version, open a PR from `next` into `stable` using this [compare link](https://github.com/nteract/data-explorer/compare/stable...next).
+- To release a new `stable` on NPM (aka the `latest` tag), open a PR from `next` into `stable` using this [compare link](https://github.com/nteract/data-explorer/compare/stable...next).
   - When merging from `next` into `stable`, please use the `create a merge commit` strategy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,15 @@ yarn run commit
 ```
 
 Consistent formatting allows us to keep the [changelog](./CHANGELOG.md) up to date automatically, and ensures future developers have a readable timeline of changes over time. For more information, see the [commitizen project page](https://github.com/commitizen/cz-cli).
+
+## How Publishing works
+
+## Publishing
+
+Publishing is handled by a 2-branch [pre-release process](https://intuit.github.io/auto/docs/generated/shipit#next-branch-default), configured in `release.yml`. All changes should be based off of the default `next` branch. Changes are published when a `release` tag is included on the PR.
+
+- To prevent a change from creating a release, use the `skip-release` label.
+- PRs made into the default branch are deployed to the `next` pre-release tag on NPM. The result can be installed with `npm install @nteract/data-explorer@next`.
+  - When merging into `next`, please use the `create a merge commit` strategy. If `rebase` is used, auto won't be able to detect which PR introduced a particular set of commits..
+- To release a new stable version, open a PR from `next` into `stable` using this [compare link](https://github.com/nteract/data-explorer/compare/stable...next).
+  - When merging from `next` into `stable`, please use the `create a merge commit` strategy.


### PR DESCRIPTION
## Motivation

- Presently, every update tagged with `release` to data-explorer would modify the `latest` channel on NPM. Having a separate pre-release channel allows bugs / features to be tested by those opting in to an experimental version before rolling  out to everyone.
- This PR permits every accepted PR to go out to `next` tag for ease of testing, but allows maintainers to control the rate of outflow to the main `latest` tag through manual merges from `next` -> `stable`.

## Changes

- Updates base branch from `main` to `next`
- Updates docs (based on notes written for Vega: https://github.com/vega/vega-tooltip/pull/566 )

## Background / Notes

- Similar 

Original message from Nteract slack channel:

> (Process suggestion) - merging into stable to create a production release
> 
> I've been setting up build systems for a few projects lately, and noticed a pattern that we might find useful here (storybookjs/storybook is probably the biggest example)
> 
> Rather than having main as the base branch, projects are releasing a dev /next prerelease as the default branch. That branch always releases a new version to the next tag on NPM. To make a stable release that updates the latest tag on NPM, you just merge next  into your production branch (I recommend calling it stable ).
> 
> I think this would be a good pattern to follow in data-explorer too, but wanted to check with others before making the chance. (It would affect modifying the workflows in the .github  folder to check for next  instead of main as the primary branch). The effect of this is that instead of remembering to apply tags to decide whether or not a PR should be released to NPM upon merge, you can safely approve everything right into the pre-release branch, and do any necessary fixes before it gets merged into stable  for an "official" release.
> 
> Let me know if you have any questions or concerns about how this would work (I'll leave this open for a week to give people time to see/think about it before doing anything).

Some additional background on the rationale behind this release process:

https://github.com/vega/ts-json-schema-generator/pull/856#issuecomment-881789210